### PR TITLE
Delete Icon Visibility Fix in `SavedPage` + Minor UI Enhancements in `LyricsPage`

### DIFF
--- a/app/src/main/java/com/shub39/rush/component/SongCard.kt
+++ b/app/src/main/java/com/shub39/rush/component/SongCard.kt
@@ -30,52 +30,53 @@ fun SongCard(
     onClick: () -> Unit,
     onDelete: () -> Unit,
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(start = 16.dp, end = 16.dp)
-            .clickable { onClick() }
-    ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(4.dp),
+                .clickable { onClick() }
+                .padding(start = 15.dp, bottom = 7.5.dp, top = 7.5.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Start
+            horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            ArtFromUrl(
-                imageUrl = result.artUrl,
-                contentDescription = result.title,
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier
-                    .size(70.dp)
-                    .clip(MaterialTheme.shapes.small),
-            )
-            Column(
-                modifier = Modifier
-                    .padding(start = 8.dp)
-                    .width(240.dp)
+                    .fillMaxWidth(0.8f)
             ) {
-                Text(
-                    text = result.title,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                ArtFromUrl(
+                    imageUrl = result.artUrl,
+                    contentDescription = result.title,
+                    modifier = Modifier
+                        .size(70.dp)
+                        .clip(MaterialTheme.shapes.small),
                 )
-                Text(
-                    text = result.artists,
-                    style = MaterialTheme.typography.bodyMedium,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
+                Column(
+                    modifier = Modifier
+                        .padding(start = 10.dp)
+                ) {
+                    Text(
+                        text = result.title,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = result.artists,
+                        style = MaterialTheme.typography.bodyMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
             }
-            Spacer(modifier = Modifier.weight(1f))
-            IconButton(onClick = { onDelete() }) {
-                Icon(
-                    painter = painterResource(id = R.drawable.round_delete_forever_24),
-                    contentDescription = null,
-                )
+            Row {
+                IconButton(onClick = { onDelete() }) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.round_delete_forever_24),
+                        contentDescription = null,
+                    )
+                }
+                Spacer(modifier = Modifier.width(15.dp))
             }
         }
-    }
 }

--- a/app/src/main/java/com/shub39/rush/page/LyricsPage.kt
+++ b/app/src/main/java/com/shub39/rush/page/LyricsPage.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -18,6 +19,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Clear
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FloatingActionButton
@@ -154,60 +157,65 @@ fun LyricsPage(
                 contentColor = MaterialTheme.colorScheme.onPrimaryContainer
             )
         ) {
-            Row(
-                modifier = Modifier.padding(16.dp),
-            ) {
-                ArtFromUrl(
-                    imageUrl = nonNullSong.artUrl,
-                    modifier = Modifier
-                        .size(150.dp)
-                        .clip(MaterialTheme.shapes.small)
-                        .drawWithContent {
-                            artGraphicsLayer.record {
-                                this@drawWithContent.drawContent()
-                            }
-                            drawLayer(artGraphicsLayer)
-                        }
-                        .pointerInput(Unit) {
-                            detectTapGestures(
-                                onLongPress = {
-                                    coroutineScope.launch {
-                                        val bitmap =
-                                            artGraphicsLayer
-                                                .toImageBitmap()
-                                                .asAndroidBitmap()
-                                        shareImage(context, bitmap)
-                                    }
-                                }
-                            )
-                        },
-                )
-                Column(
-                    modifier = Modifier.padding(start = 16.dp, end = 16.dp)
+            Column {
+                Row(
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text(
-                        text = nonNullSong.title,
-                        style = MaterialTheme.typography.titleLarge,
-                        fontWeight = FontWeight.SemiBold,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis
+                    ArtFromUrl(
+                        imageUrl = nonNullSong.artUrl,
+                        modifier = Modifier
+                            .size(100.dp)
+                            .clip(MaterialTheme.shapes.small)
+                            .drawWithContent {
+                                artGraphicsLayer.record {
+                                    this@drawWithContent.drawContent()
+                                }
+                                drawLayer(artGraphicsLayer)
+                            }
+                            .pointerInput(Unit) {
+                                detectTapGestures(
+                                    onLongPress = {
+                                        coroutineScope.launch {
+                                            val bitmap =
+                                                artGraphicsLayer
+                                                    .toImageBitmap()
+                                                    .asAndroidBitmap()
+                                            shareImage(context, bitmap)
+                                        }
+                                    }
+                                )
+                            },
                     )
-                    Text(
-                        text = nonNullSong.artists,
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.Bold,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                    nonNullSong.album?.let {
+                    Column(
+                        modifier = Modifier.padding(start = 16.dp, end = 16.dp),
+                    ) {
                         Text(
-                            text = it,
+                            text = nonNullSong.title,
+                            style = MaterialTheme.typography.titleLarge,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        Text(
+                            text = nonNullSong.artists,
                             style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Bold,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )
+                        nonNullSong.album?.let {
+                            Text(
+                                text = it,
+                                style = MaterialTheme.typography.bodyMedium,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
                     }
-                    Row {
+                }
+                Box(modifier = Modifier.fillMaxWidth().padding(end = 16.dp), contentAlignment = Alignment.CenterEnd){
+                    Row(verticalAlignment = Alignment.CenterVertically) {
                         IconButton(
                             onClick = {
                                 if (selectedLines.isEmpty()) {
@@ -271,7 +279,7 @@ fun LyricsPage(
                                 }
                                 IconButton(onClick = { selectedLines = emptyMap() }) {
                                     Icon(
-                                        painter = painterResource(id = R.drawable.round_delete_forever_24),
+                                        imageVector = Icons.Rounded.Clear,
                                         contentDescription = null
                                     )
                                 }

--- a/app/src/main/java/com/shub39/rush/page/SharePage.kt
+++ b/app/src/main/java/com/shub39/rush/page/SharePage.kt
@@ -295,6 +295,7 @@ fun SharePage(
                 ) {
                     Row(
                         modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp),
+                        verticalAlignment = Alignment.CenterVertically
                     ) {
                         ArtFromUrl(
                             imageUrl = song.artUrl,
@@ -336,7 +337,7 @@ fun SharePage(
                                     text = it.value,
                                     style = MaterialTheme.typography.bodyLarge,
                                     fontWeight = FontWeight.Bold,
-                                    modifier = Modifier.padding(8.dp)
+                                    modifier = Modifier.padding(start = 0.dp, top = 0.dp, bottom = 8.dp, end = 8.dp)
                                 )
                             }
                         }


### PR DESCRIPTION
- The delete icon button in `SavedPage` [wasn’t visible](https://github.com/user-attachments/assets/8c96e65a-e5e8-4446-996b-c16d28844c69) (at least in the latest release); this has been fixed.
- [Updated](https://github.com/user-attachments/assets/3f18259d-1e8d-4593-bd4a-13506ff98e1f) the top section of `LyricsPage` where the artwork was too large, and the icon buttons were inconsistent.
