### PR TITLE
Automatically update current player position

### DIFF
--- a/app/src/main/java/com/shub39/rush/listener/MediaListener.kt
+++ b/app/src/main/java/com/shub39/rush/listener/MediaListener.kt
@@ -25,6 +25,7 @@ object MediaListener {
     private val internalCallbacks = mutableMapOf<MediaSession.Token, MediaController.Callback>()
     val songInfoFlow = MutableSharedFlow<Pair<String, String>>()
     val songPositionFlow = MutableSharedFlow<Long>()
+    val playbackSpeedFlow = MutableSharedFlow<Float>()
 
     private var initialised = false
 
@@ -123,6 +124,12 @@ object MediaListener {
 
         coroutineScope.launch {
             songInfoFlow.emit(Pair(getMainTitle(title), artist))
+            playbackSpeedFlow.emit(
+                // Just as a safety measure, not all player controllers report proper speed
+                if (controller.playbackState?.let { isActive(it) } == true)
+                    controller.playbackState?.playbackSpeed ?: 1f
+                else 0f
+            )
             controller.playbackState?.position?.let { songPositionFlow.emit(it) }
         }
     }


### PR DESCRIPTION
This pull request adds auto-scroll to the lyrics tab.
It achieves this by updating the position considering the initial player position and the current player speed.


For the implementation I wasn't entirely sure where to put the code that updates the current speed, so I just put it next to the code that updates the player position.
Maybe `updateTitle` is/was not the best name for this function, but I wasn't sure if I wanted to rename it so I'll leave that up to you to decide.


Thank you for the app, it looks really nice!