### PR TITLE
fix wrong translation link

### DIFF
--- a/app/src/androidMain/kotlin/com/shub39/rush/lyrics/presentation/setting/About.kt
+++ b/app/src/androidMain/kotlin/com/shub39/rush/lyrics/presentation/setting/About.kt
@@ -155,7 +155,7 @@ fun About(
                 Row(modifier = Modifier.padding(horizontal = 16.dp)) {
                     FilledTonalButton(
                         onClick = {
-                            uriHandler.openUri("https://buymeacoffee.com/shub39")
+                            uriHandler.openUri("https://hosted.weblate.org/engage/rush")
                         },
                         modifier = Modifier.weight(1f)
                     ) {


### PR DESCRIPTION
Fix wrong link of the translation site in the about page