### PR TITLE
Betas publish as a Pre-release on GitHub

### DIFF
--- a/.github/workflows/beta-.yml
+++ b/.github/workflows/beta-.yml
@@ -48,6 +48,17 @@ jobs:
           name: beta-apk
           path: app/build/outputs/apk/beta/app-beta.apk
 
+      - name: Create prerelease
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: beta-${{ github.run_id }}
+          release_name: Beta ${{ github.run_id }}
+          draft: false
+          prerelease: true
+
       - name: Upload APK to prerelease
         uses: actions/upload-release-asset@v1
         env:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced a new workflow to automatically build and upload a beta APK for Android on pushes to the master branch or when manually triggered.
  * The beta APK is uploaded as an artifact and attached to a GitHub prerelease.
  * Notifications about new beta builds are sent to a Discord channel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->