### PR TITLE
:wrench: improved notification service naming

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,7 +39,8 @@
             android:enabled="true"
             android:exported="true"
             android:process=":NLS"
-            android:label="Notification Listener Service">
+            android:label="@string/app_name"
+            android:description="@string/notification_permission">
             <intent-filter>
                 <action android:name="android.service.notification.NotificationListenerService" />
             </intent-filter>


### PR DESCRIPTION
fixes #176.

<img width="430" height="310" alt="Notification Listener Service is now named just like an app (here, Rush Debug)" src="https://github.com/user-attachments/assets/00b17abb-936b-41dc-a421-8cfbca93ccd3" />
