### PR TITLE
Improve performance and layout management in Lyrics page

### DIFF
--- a/app/src/main/java/com/shub39/rush/domain/dataclasses/ParsedLine.kt
+++ b/app/src/main/java/com/shub39/rush/domain/dataclasses/ParsedLine.kt
@@ -16,6 +16,9 @@
  */
 package com.shub39.rush.domain.dataclasses
 
+import androidx.compose.runtime.Stable
+
+@Stable
 data class ParsedLine(
     val text: String,
     val startTime: Double,

--- a/app/src/main/java/com/shub39/rush/domain/dataclasses/ParsedWord.kt
+++ b/app/src/main/java/com/shub39/rush/domain/dataclasses/ParsedWord.kt
@@ -18,5 +18,4 @@ package com.shub39.rush.domain.dataclasses
 
 import androidx.compose.runtime.Immutable
 
-@Immutable
-data class ParsedWord(val text: String, val startTime: Double, val endTime: Double)
+@Immutable data class ParsedWord(val text: String, val startTime: Double, val endTime: Double)

--- a/app/src/main/java/com/shub39/rush/domain/dataclasses/ParsedWord.kt
+++ b/app/src/main/java/com/shub39/rush/domain/dataclasses/ParsedWord.kt
@@ -16,4 +16,7 @@
  */
 package com.shub39.rush.domain.dataclasses
 
+import androidx.compose.runtime.Immutable
+
+@Immutable
 data class ParsedWord(val text: String, val startTime: Double, val endTime: Double)

--- a/app/src/main/java/com/shub39/rush/presentation/Util.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/Util.kt
@@ -21,9 +21,7 @@ import android.content.ClipData
 import android.content.Context
 import android.content.ContextWrapper
 import android.os.Build
-import android.view.WindowManager
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
+import android.view.View
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.draw.rotate
@@ -35,7 +33,6 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.Clipboard
-import androidx.compose.ui.platform.LocalContext
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
@@ -43,21 +40,6 @@ import androidx.core.view.WindowInsetsControllerCompat
 fun hypnoticAvailable() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
 
 fun blurAvailable() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
-
-@Composable
-fun KeepScreenOn() {
-    val context = LocalContext.current
-
-    DisposableEffect(Unit) {
-        context.findActivity()?.window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-        onDispose {
-            context
-                .findActivity()
-                ?.window
-                ?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-        }
-    }
-}
 
 suspend fun Clipboard.copyToClipboard(text: String) {
     setClipEntry(ClipEntry(ClipData.newPlainText("lyrics", text)))
@@ -72,19 +54,25 @@ fun Context.findActivity(): Activity? {
     return null
 }
 
-fun updateSystemBars(context: Context, show: Boolean) {
-    val window = context.findActivity()?.window ?: return
-    val insetsController = WindowCompat.getInsetsController(window, window.decorView)
+fun updateSystemBars(view: View, fullscreen: Boolean) {
+    val window = view.context.findActivity()?.window ?: return
+    val controller = WindowCompat.getInsetsController(window, view)
 
-    insetsController.apply {
-        if (show) {
-            show(WindowInsetsCompat.Type.systemBars())
-            systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
-        } else {
-            hide(WindowInsetsCompat.Type.systemBars())
-            systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-        }
+    if (fullscreen) {
+        controller.hide(WindowInsetsCompat.Type.systemBars())
+        controller.systemBarsBehavior =
+            WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+    } else {
+        controller.show(WindowInsetsCompat.Type.systemBars())
+        controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
     }
+}
+
+fun resetSystemBars(view: View) {
+    val window = view.context.findActivity()?.window ?: return
+    val controller = WindowCompat.getInsetsController(window, view)
+    controller.show(WindowInsetsCompat.Type.systemBars())
+    controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
 }
 
 fun sortMapByKeys(map: Map<Int, String>): Map<Int, String> {

--- a/app/src/main/java/com/shub39/rush/presentation/Util.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/Util.kt
@@ -166,6 +166,17 @@ fun Modifier.rotateVertically(clockwise: Boolean = true): Modifier {
     return rotate then adjustBounds
 }
 
+fun Modifier.conditional(
+    condition: Boolean,
+    modifier: Modifier.() -> Modifier
+): Modifier {
+    return if (condition) {
+        then(modifier(Modifier))
+    } else {
+        this
+    }
+}
+
 // very important
 private val brainrots =
     listOf(

--- a/app/src/main/java/com/shub39/rush/presentation/Util.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/Util.kt
@@ -166,10 +166,7 @@ fun Modifier.rotateVertically(clockwise: Boolean = true): Modifier {
     return rotate then adjustBounds
 }
 
-fun Modifier.conditional(
-    condition: Boolean,
-    modifier: Modifier.() -> Modifier
-): Modifier {
+fun Modifier.conditional(condition: Boolean, modifier: Modifier.() -> Modifier): Modifier {
     return if (condition) {
         then(modifier(Modifier))
     } else {

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/LyricsGraph.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/LyricsGraph.kt
@@ -25,7 +25,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.dp
@@ -40,6 +40,7 @@ import com.shub39.rush.navigation.horizontalTransitionMetadata
 import com.shub39.rush.presentation.RushPreviewWrapper
 import com.shub39.rush.presentation.lyrics.section.LyricsCustomisationsPage
 import com.shub39.rush.presentation.lyrics.section.LyricsPage
+import com.shub39.rush.presentation.resetSystemBars
 import com.shub39.rush.presentation.updateSystemBars
 import io.gitlab.bpavuk.viz.VisualizerState
 import io.gitlab.bpavuk.viz.rememberVisualizerState
@@ -58,7 +59,6 @@ fun LyricsGraph(
     lyricsAction: (LyricsPageAction) -> Unit,
     onShare: () -> Unit,
 ) {
-    val context = LocalContext.current
     val backStack = rememberNavBackStack(LyricsPage)
 
     val microphonePermission = rememberPermissionState(Manifest.permission.RECORD_AUDIO)
@@ -74,9 +74,11 @@ fun LyricsGraph(
         entryProvider =
             entryProvider {
                 entry<LyricsPage> {
-                    DisposableEffect(Unit) {
-                        updateSystemBars(context, show = !lyricsState.fullscreen)
-                        onDispose { updateSystemBars(context, show = true) }
+                    val view = LocalView.current
+
+                    DisposableEffect(view, lyricsState.fullscreen) {
+                        updateSystemBars(view, lyricsState.fullscreen)
+                        onDispose { resetSystemBars(view) }
                     }
 
                     LyricsPage(

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/Util.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/Util.kt
@@ -114,6 +114,18 @@ fun getCurrentLyricIndex(playbackPosition: Long, lyrics: List<Lyric>): Int {
     }
 }
 
+@Composable
+fun rememberLineProgress(currentTime: Long, startTime: Double, nextTime: Double?): Float {
+    return androidx.compose.runtime.remember(currentTime, startTime, nextTime) {
+        nextTime?.let { nt ->
+            val currentSecs = currentTime / 1000.0
+            val denom = (nt - startTime).toFloat()
+            if (denom <= 0f) 1f
+            else ((currentSecs - startTime).toFloat() / denom).coerceIn(0f, 1f)
+        } ?: 1f
+    }
+}
+
 fun getNextLyricTime(index: Int, lyrics: List<Lyric>): Long? {
     return lyrics.getOrNull(index + 1)?.time
 }

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/Util.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/Util.kt
@@ -120,8 +120,7 @@ fun rememberLineProgress(currentTime: Long, startTime: Double, nextTime: Double?
         nextTime?.let { nt ->
             val currentSecs = currentTime / 1000.0
             val denom = (nt - startTime).toFloat()
-            if (denom <= 0f) 1f
-            else ((currentSecs - startTime).toFloat() / denom).coerceIn(0f, 1f)
+            if (denom <= 0f) 1f else ((currentSecs - startTime).toFloat() / denom).coerceIn(0f, 1f)
         } ?: 1f
     }
 }

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/Actions.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/Actions.kt
@@ -22,6 +22,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -31,16 +33,26 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.unit.dp
 import com.shub39.rush.R
 import com.shub39.rush.domain.dataclasses.SongDetails
+import com.shub39.rush.domain.dataclasses.SongUi
 import com.shub39.rush.domain.enums.Sources
 import com.shub39.rush.presentation.copyToClipboard
 import com.shub39.rush.presentation.lyrics.LyricsPageAction
-import com.shub39.rush.presentation.lyrics.LyricsPageState
-import com.shub39.rush.presentation.lyrics.LyricsState
 import kotlinx.coroutines.launch
+
+@Immutable
+@Stable
+data class ActionsState(
+    val song: SongUi?,
+    val selectedLines: Map<Int, String>,
+    val source: Sources,
+    val syncedAvailable: Boolean,
+    val sync: Boolean,
+    val autoChange: Boolean,
+)
 
 @Composable
 fun Actions(
-    state: LyricsPageState,
+    state: ActionsState,
     action: (LyricsPageAction) -> Unit,
     notificationAccess: Boolean,
     cardBackground: Color,
@@ -57,22 +69,17 @@ fun Actions(
 
     IconButton(
         onClick = {
-            if (state.lyricsState is LyricsState.Loaded) {
+            if (state.song != null) {
                 coroutineScope.launch {
                     clipboardManager.copyToClipboard(
                         if (state.selectedLines.isEmpty()) {
                                 buildAnnotatedString {
                                     append(
                                         if (state.source == Sources.LRCLIB) {
-                                            state.lyricsState.song.lyrics.joinToString("\n") {
-                                                it.value
-                                            }
+                                            state.song.lyrics.joinToString("\n") { it.value }
                                         } else {
-                                            state.lyricsState.song.geniusLyrics?.joinToString(
-                                                "\n"
-                                            ) {
-                                                it.value
-                                            } ?: ""
+                                            state.song.geniusLyrics?.joinToString("\n") { it.value }
+                                                ?: ""
                                         }
                                     )
                                 }
@@ -176,15 +183,15 @@ fun Actions(
     if (state.selectedLines.isNotEmpty()) {
         IconButton(
             onClick = {
-                if (state.lyricsState is LyricsState.Loaded) {
+                if (state.song != null) {
                     action(
                         LyricsPageAction.OnUpdateShareLines(
                             songDetails =
                                 SongDetails(
-                                    title = state.lyricsState.song.title,
-                                    artist = state.lyricsState.song.artists,
-                                    album = state.lyricsState.song.album,
-                                    artUrl = state.lyricsState.song.artUrl ?: "",
+                                    title = state.song.title,
+                                    artist = state.song.artists,
+                                    album = state.song.album,
+                                    artUrl = state.song.artUrl ?: "",
                                 )
                         )
                     )

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/Actions.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/Actions.kt
@@ -22,8 +22,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.Stable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -39,8 +37,6 @@ import com.shub39.rush.presentation.copyToClipboard
 import com.shub39.rush.presentation.lyrics.LyricsPageAction
 import kotlinx.coroutines.launch
 
-@Immutable
-@Stable
 data class ActionsState(
     val song: SongUi?,
     val selectedLines: Map<Int, String>,

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/BaseSyncedLyrics.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/BaseSyncedLyrics.kt
@@ -19,6 +19,7 @@ package com.shub39.rush.presentation.lyrics.component
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyItemScope
@@ -42,6 +43,7 @@ import com.shub39.rush.presentation.lyrics.LyricsPageState
 import com.shub39.rush.presentation.lyrics.PlaybackInfo
 import kotlin.math.abs
 import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 fun <T> BaseSyncedLyrics(
@@ -102,7 +104,7 @@ fun <T> BaseSyncedLyrics(
     // scroll interaction
     LaunchedEffect(isUserScrolling) {
         if (!isUserScrolling) {
-            delay(3000)
+            delay(3000.milliseconds)
             pauseAutoScroll = false
         } else {
             pauseAutoScroll = true
@@ -126,7 +128,6 @@ fun <T> BaseSyncedLyrics(
                 )
 
             BaseSyncedItemWrapper(
-                index = index,
                 onHeightMeasured = { itemHeights[index] = it },
                 content = { itemContent(index, item, blur) },
             )
@@ -136,11 +137,10 @@ fun <T> BaseSyncedLyrics(
 
 @Composable
 private fun BaseSyncedItemWrapper(
-    index: Int,
     onHeightMeasured: (Int) -> Unit,
     content: @Composable () -> Unit,
 ) {
-    androidx.compose.foundation.layout.Box(
+    Box(
         modifier =
             Modifier.onGloballyPositioned { layoutCoordinates ->
                 onHeightMeasured(layoutCoordinates.size.height)

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/BaseSyncedLyrics.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/BaseSyncedLyrics.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2026  Shubham Gorai
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.shub39.rush.presentation.lyrics.component
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.interaction.collectIsDraggedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyItemScope
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.shub39.rush.presentation.lyrics.LyricsPageState
+import com.shub39.rush.presentation.lyrics.PlaybackInfo
+import kotlin.math.abs
+import kotlinx.coroutines.delay
+
+@Composable
+fun <T> BaseSyncedLyrics(
+    state: LyricsPageState,
+    playbackInfo: PlaybackInfo,
+    lazyListState: LazyListState,
+    items: List<T>,
+    currentPlayingIndex: Int,
+    modifier: Modifier = Modifier,
+    itemKey: ((Int, T) -> Any)? = null,
+    itemContent: @Composable LazyItemScope.(index: Int, item: T, blur: Dp) -> Unit
+) {
+    val isUserScrolling by lazyListState.interactionSource.collectIsDraggedAsState()
+    var pauseAutoScroll by remember { mutableStateOf(false) }
+    val density = LocalDensity.current
+
+    val itemHeights = remember { mutableStateMapOf<Int, Int>() }
+
+    val lineSpacing =
+        remember(state.textPrefs.lineHeight, density) {
+            with(density) { state.textPrefs.lineHeight.sp.toDp() / 2 }
+        }
+
+    // updater for synced lyrics
+    LaunchedEffect(
+        currentPlayingIndex,
+        pauseAutoScroll,
+        isUserScrolling,
+        playbackInfo.speed,
+        itemHeights[currentPlayingIndex],
+    ) {
+        if (currentPlayingIndex < 0 || pauseAutoScroll || isUserScrolling || playbackInfo.speed == 0f) {
+            return@LaunchedEffect
+        }
+
+        val viewportHeight =
+            lazyListState.layoutInfo.viewportEndOffset -
+                lazyListState.layoutInfo.viewportStartOffset
+        val itemHeight = itemHeights[currentPlayingIndex] ?: 0
+        val centerOffset = (viewportHeight / 3) - (itemHeight / 2)
+        val distance = abs(currentPlayingIndex - lazyListState.firstVisibleItemIndex)
+
+        if (distance > 10) {
+            lazyListState.scrollToItem(index = currentPlayingIndex, scrollOffset = -centerOffset)
+        } else {
+            lazyListState.animateScrollToItem(
+                index = currentPlayingIndex,
+                scrollOffset = -centerOffset,
+            )
+        }
+    }
+
+    // scroll interaction
+    LaunchedEffect(isUserScrolling) {
+        if (!isUserScrolling) {
+            delay(3000)
+            pauseAutoScroll = false
+        } else {
+            pauseAutoScroll = true
+        }
+    }
+
+    LazyColumn(
+        modifier = modifier,
+        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 64.dp, bottom = 256.dp),
+        verticalArrangement = Arrangement.spacedBy(lineSpacing),
+        state = lazyListState,
+    ) {
+        itemsIndexed(items = items, key = itemKey) { index, item ->
+            val blur by
+                animateDpAsState(
+                    targetValue =
+                        if (!state.blurSyncedLyrics || pauseAutoScroll) 0.dp
+                        else (abs(index - currentPlayingIndex) * 3).coerceIn(0..10).dp,
+                    animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+                    label = "blur",
+                )
+
+            BaseSyncedItemWrapper(
+                index = index,
+                onHeightMeasured = { itemHeights[index] = it },
+                content = { itemContent(index, item, blur) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun BaseSyncedItemWrapper(
+    index: Int,
+    onHeightMeasured: (Int) -> Unit,
+    content: @Composable () -> Unit,
+) {
+    androidx.compose.foundation.layout.Box(
+        modifier = Modifier.onGloballyPositioned { layoutCoordinates ->
+            onHeightMeasured(layoutCoordinates.size.height)
+        }
+    ) {
+        content()
+    }
+}

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/BaseSyncedLyrics.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/BaseSyncedLyrics.kt
@@ -52,7 +52,7 @@ fun <T> BaseSyncedLyrics(
     currentPlayingIndex: Int,
     modifier: Modifier = Modifier,
     itemKey: ((Int, T) -> Any)? = null,
-    itemContent: @Composable LazyItemScope.(index: Int, item: T, blur: Dp) -> Unit
+    itemContent: @Composable LazyItemScope.(index: Int, item: T, blur: Dp) -> Unit,
 ) {
     val isUserScrolling by lazyListState.interactionSource.collectIsDraggedAsState()
     var pauseAutoScroll by remember { mutableStateOf(false) }
@@ -73,7 +73,12 @@ fun <T> BaseSyncedLyrics(
         playbackInfo.speed,
         itemHeights[currentPlayingIndex],
     ) {
-        if (currentPlayingIndex < 0 || pauseAutoScroll || isUserScrolling || playbackInfo.speed == 0f) {
+        if (
+            currentPlayingIndex < 0 ||
+                pauseAutoScroll ||
+                isUserScrolling ||
+                playbackInfo.speed == 0f
+        ) {
             return@LaunchedEffect
         }
 
@@ -136,9 +141,10 @@ private fun BaseSyncedItemWrapper(
     content: @Composable () -> Unit,
 ) {
     androidx.compose.foundation.layout.Box(
-        modifier = Modifier.onGloballyPositioned { layoutCoordinates ->
-            onHeightMeasured(layoutCoordinates.size.height)
-        }
+        modifier =
+            Modifier.onGloballyPositioned { layoutCoordinates ->
+                onHeightMeasured(layoutCoordinates.size.height)
+            }
     ) {
         content()
     }

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/BaseSyncedLyrics.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/BaseSyncedLyrics.kt
@@ -42,8 +42,8 @@ import androidx.compose.ui.unit.sp
 import com.shub39.rush.presentation.lyrics.LyricsPageState
 import com.shub39.rush.presentation.lyrics.PlaybackInfo
 import kotlin.math.abs
-import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
 
 @Composable
 fun <T> BaseSyncedLyrics(

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/LineSyncedLyrics.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/LineSyncedLyrics.kt
@@ -69,6 +69,7 @@ import com.shub39.rush.presentation.toAlignment
 import com.shub39.rush.presentation.toArrangement
 import com.shub39.rush.presentation.toTextAlignment
 import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 fun LineSyncedLyrics(
@@ -281,7 +282,7 @@ private fun LineSyncedLyricsPreview() {
         while (true) {
             val elapsed = System.currentTimeMillis() - startTime
             position = elapsed % 27000
-            delay(16)
+            delay(16.milliseconds)
         }
     }
 

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/LineSyncedLyrics.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/LineSyncedLyrics.kt
@@ -68,8 +68,8 @@ import com.shub39.rush.presentation.lyrics.toTransformOrigin
 import com.shub39.rush.presentation.toAlignment
 import com.shub39.rush.presentation.toArrangement
 import com.shub39.rush.presentation.toTextAlignment
-import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
 
 @Composable
 fun LineSyncedLyrics(

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/LineSyncedLyrics.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/LineSyncedLyrics.kt
@@ -104,11 +104,12 @@ fun LineSyncedLyrics(
         val currentTime = playbackInfo.position
         val isCurrent = index == currentPlayingIndex
 
-        val progress = rememberLineProgress(
-            currentTime = currentTime,
-            startTime = lyric.time / 1000.0,
-            nextTime = nextTime?.toDouble()?.div(1000.0)
-        )
+        val progress =
+            rememberLineProgress(
+                currentTime = currentTime,
+                startTime = lyric.time / 1000.0,
+                nextTime = nextTime?.toDouble()?.div(1000.0),
+            )
 
         val animatedProgress by
             animateFloatAsState(

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/LineSyncedLyrics.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/LineSyncedLyrics.kt
@@ -259,7 +259,7 @@ fun SyncedLyric(
 @PreviewWrapper(RushPreviewWrapper::class)
 @Preview
 @Composable
-fun LineSyncedLyricsPreview() {
+private fun LineSyncedLyricsPreview() {
     var position by remember { mutableLongStateOf(0L) }
     val lyrics = remember {
         listOf(

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/LineSyncedLyrics.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/LineSyncedLyrics.kt
@@ -20,18 +20,13 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.collectIsDraggedAsState
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -40,8 +35,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
-import androidx.compose.runtime.mutableStateMapOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -52,8 +45,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -72,11 +63,11 @@ import com.shub39.rush.presentation.lyrics.PlayingSong
 import com.shub39.rush.presentation.lyrics.TextPrefs
 import com.shub39.rush.presentation.lyrics.getCurrentLyricIndex
 import com.shub39.rush.presentation.lyrics.getNextLyricTime
+import com.shub39.rush.presentation.lyrics.rememberLineProgress
 import com.shub39.rush.presentation.lyrics.toTransformOrigin
 import com.shub39.rush.presentation.toAlignment
 import com.shub39.rush.presentation.toArrangement
 import com.shub39.rush.presentation.toTextAlignment
-import kotlin.math.abs
 import kotlinx.coroutines.delay
 
 @Composable
@@ -88,125 +79,88 @@ fun LineSyncedLyrics(
     action: (LyricsPageAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val isUserScrolling by lazyListState.interactionSource.collectIsDraggedAsState()
-    var pauseAutoScroll by remember { mutableStateOf(false) }
-
-    val itemHeights = remember { mutableStateMapOf<Int, Int>() }
-
-    val syncedLyrics = (state.lyricsState as? LyricsState.Loaded)?.song?.syncedLyrics ?: return
-
-    // updater for synced lyrics
-    LaunchedEffect(playbackInfo.position, pauseAutoScroll) {
-        if (!pauseAutoScroll) {
-            val currentIndex =
-                getCurrentLyricIndex(playbackInfo.position, syncedLyrics).coerceAtLeast(0)
-            val viewportHeight =
-                lazyListState.layoutInfo.viewportEndOffset -
-                    lazyListState.layoutInfo.viewportStartOffset
-            val itemHeight = itemHeights[currentIndex] ?: 0
-            val centerOffset = (viewportHeight / 4) - (itemHeight / 2)
-            lazyListState.animateScrollToItem(index = currentIndex, scrollOffset = -centerOffset)
+    val song = (state.lyricsState as? LyricsState.Loaded)?.song ?: return
+    val syncedLyrics = song.syncedLyrics ?: return
+    val currentPlayingIndex =
+        remember(playbackInfo.position, syncedLyrics) {
+            getCurrentLyricIndex(playbackInfo.position, syncedLyrics).coerceAtLeast(0)
         }
-    }
 
-    // scroll interaction
-    LaunchedEffect(isUserScrolling) {
-        if (!isUserScrolling) {
-            delay(3000)
-            pauseAutoScroll = false
-        } else {
-            pauseAutoScroll = true
+    val romanizedSynced =
+        remember(state.romanizationEnabled, song) {
+            if (state.romanizationEnabled) song.romanizedSyncedLyrics else emptyMap()
         }
-    }
 
-    // Synced Lyrics
-    LazyColumn(
+    BaseSyncedLyrics(
+        state = state,
+        playbackInfo = playbackInfo,
+        lazyListState = lazyListState,
+        items = syncedLyrics,
+        currentPlayingIndex = currentPlayingIndex,
+        itemKey = { _, lyric -> lyric.time },
         modifier = modifier,
-        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 64.dp, bottom = 256.dp),
-        verticalArrangement =
-            Arrangement.spacedBy(
-                with(LocalDensity.current) { state.textPrefs.lineHeight.sp.toDp() / 2 }
-            ),
-        state = lazyListState,
-    ) {
-        itemsIndexed(items = syncedLyrics, key = { index, _ -> index }) { index, lyric ->
-            val nextTime = getNextLyricTime(index, syncedLyrics)
-            val currentTime = playbackInfo.position
-            val lyricIndex = syncedLyrics.indexOf(lyric)
-            val currentPlayingIndex = getCurrentLyricIndex(playbackInfo.position, syncedLyrics)
-            val isCurrent = lyricIndex == currentPlayingIndex
+    ) { index, lyric, blur ->
+        val nextTime = getNextLyricTime(index, syncedLyrics)
+        val currentTime = playbackInfo.position
+        val isCurrent = index == currentPlayingIndex
 
-            val progress =
-                nextTime?.let { nt ->
-                    val denom = (nt - lyric.time).toFloat()
-                    if (denom <= 0f) 1f
-                    else ((currentTime - lyric.time).toFloat() / denom).coerceIn(0f, 1f)
-                } ?: 1f
+        val progress = rememberLineProgress(
+            currentTime = currentTime,
+            startTime = lyric.time / 1000.0,
+            nextTime = nextTime?.toDouble()?.div(1000.0)
+        )
 
-            val animatedProgress by
-                animateFloatAsState(
-                    targetValue = progress,
-                    animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-                )
-
-            val underTextAlpha by
-                animateFloatAsState(
-                    targetValue = if (isCurrent) 0.5f else 0.2f,
-                    animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-                )
-
-            val blur by
-                animateDpAsState(
-                    targetValue =
-                        if (!state.blurSyncedLyrics || pauseAutoScroll) 0.dp
-                        else (abs(lyricIndex - currentPlayingIndex) * 3).coerceIn(0..10).dp,
-                    animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-                )
-
-            val scale by
-                animateFloatAsState(
-                    targetValue = if (isCurrent) 1f else 0.8f,
-                    animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
-                )
-
-            val textColor by
-                animateColorAsState(
-                    targetValue =
-                        when {
-                            lyric.time <= playbackInfo.position -> cardContent
-                            else -> cardContent.copy(0.3f)
-                        },
-                    animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-                    label = "textColor",
-                )
-
-            val glowAlpha by
-                animateDpAsState(
-                    targetValue = if (!state.blurSyncedLyrics || !isCurrent) 0.dp else 2.dp,
-                    animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-                )
-
-            SyncedLyric(
-                textPrefs = state.textPrefs,
-                blur = blur,
-                action = action,
-                lyric = lyric,
-                romanizedText =
-                    if (state.romanizationEnabled)
-                        state.lyricsState.song.romanizedSyncedLyrics[lyric.time]
-                    else null,
-                underTextAlpha = underTextAlpha,
-                glowAlpha = glowAlpha,
-                textColor = textColor,
-                scale = scale,
-                animatedProgress = animatedProgress,
-                modifier =
-                    Modifier.onGloballyPositioned { layoutCoordinates ->
-                        val height = layoutCoordinates.size.height
-                        itemHeights[index] = height
-                    },
+        val animatedProgress by
+            animateFloatAsState(
+                targetValue = progress,
+                animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+                label = "animatedProgress",
             )
-        }
+
+        val underTextAlpha by
+            animateFloatAsState(
+                targetValue = if (isCurrent) 0.5f else 0.2f,
+                animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+                label = "underTextAlpha",
+            )
+
+        val scale by
+            animateFloatAsState(
+                targetValue = if (isCurrent) 1f else 0.8f,
+                animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+                label = "scale",
+            )
+
+        val textColor by
+            animateColorAsState(
+                targetValue =
+                    when {
+                        lyric.time <= playbackInfo.position -> cardContent
+                        else -> cardContent.copy(0.3f)
+                    },
+                animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+                label = "textColor",
+            )
+
+        val glowAlpha by
+            animateDpAsState(
+                targetValue = if (!state.blurSyncedLyrics || !isCurrent) 0.dp else 2.dp,
+                animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+                label = "glowAlpha",
+            )
+
+        SyncedLyric(
+            textPrefs = state.textPrefs,
+            blur = blur,
+            action = action,
+            lyric = lyric,
+            romanizedText = romanizedSynced[lyric.time],
+            underTextAlpha = underTextAlpha,
+            glowAlpha = glowAlpha,
+            textColor = textColor,
+            scale = scale,
+            animatedProgress = animatedProgress,
+        )
     }
 }
 

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/PlainLyrics.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/PlainLyrics.kt
@@ -85,8 +85,7 @@ fun PlainLyrics(
 
     val song = (state.lyricsState as? LyricsState.Loaded)?.song ?: return
     val items = if (state.source == Sources.LRCLIB) song.lyrics else song.geniusLyrics
-    val nonEmptyItems =
-        remember(items) { items?.filter { it.value.isNotBlank() } ?: emptyList() }
+    val nonEmptyItems = remember(items) { items?.filter { it.value.isNotBlank() } ?: emptyList() }
     val shouldAutoScrape =
         state.source == Sources.GENIUS &&
             nonEmptyItems.isEmpty() &&

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/PlainLyrics.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/PlainLyrics.kt
@@ -42,6 +42,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -84,6 +85,19 @@ fun PlainLyrics(
 
     val song = (state.lyricsState as? LyricsState.Loaded)?.song ?: return
     val items = if (state.source == Sources.LRCLIB) song.lyrics else song.geniusLyrics
+    val nonEmptyItems =
+        remember(items) { items?.filter { it.value.isNotBlank() } ?: emptyList() }
+    val shouldAutoScrape =
+        state.source == Sources.GENIUS &&
+            nonEmptyItems.isEmpty() &&
+            !state.scraping.first &&
+            state.scraping.second == null
+
+    LaunchedEffect(song.id, state.source, shouldAutoScrape) {
+        if (shouldAutoScrape) {
+            action(LyricsPageAction.OnScrapeGeniusLyrics(song.id, song.sourceUrl))
+        }
+    }
 
     LazyColumn(
         modifier = modifier,
@@ -95,60 +109,53 @@ fun PlainLyrics(
         state = lazyListState,
     ) {
         // plain lyrics with logic
-        if (!items.isNullOrEmpty()) {
-            items(items = items, key = { it.key }) {
-                if (it.value.isNotBlank()) {
-                    val isSelected = state.selectedLines.contains(it.key)
-                    val containerColor by
-                        animateColorAsState(
-                            targetValue =
-                                when (!isSelected) {
-                                    true -> Color.Transparent
-                                    else -> cardContent.copy(alpha = 0.3f)
-                                },
-                            label = "container",
-                            animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-                        )
+        if (nonEmptyItems.isNotEmpty()) {
+            items(items = nonEmptyItems, key = { it.key }, contentType = { "lyric" }) {
+                val isSelected = state.selectedLines.contains(it.key)
+                val containerColor by
+                    animateColorAsState(
+                        targetValue =
+                            when (!isSelected) {
+                                true -> Color.Transparent
+                                else -> cardContent.copy(alpha = 0.3f)
+                            },
+                        label = "container",
+                        animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+                    )
 
-                    PlainLyric(
-                        entry = it.toPair(),
-                        romanizedText =
-                            if (state.romanizationEnabled)
-                                if (state.source == Sources.GENIUS)
-                                    state.lyricsState.song.romanizedGeniusLyrics[it.key]
-                                else state.lyricsState.song.romanizedLyrics[it.key]
-                            else null,
-                        containerColor = containerColor,
-                        textPrefs = state.textPrefs,
-                        cardContent = cardContent,
-                        onClick = {
-                            action(
-                                LyricsPageAction.OnChangeSelectedLines(
-                                    updateSelectedLines(
-                                        state.selectedLines,
-                                        it.key,
-                                        it.value,
-                                        state.maxLines,
-                                    )
+                PlainLyric(
+                    entry = it.toPair(),
+                    romanizedText =
+                        if (state.romanizationEnabled)
+                            if (state.source == Sources.GENIUS)
+                                state.lyricsState.song.romanizedGeniusLyrics[it.key]
+                            else state.lyricsState.song.romanizedLyrics[it.key]
+                        else null,
+                    containerColor = containerColor,
+                    textPrefs = state.textPrefs,
+                    cardContent = cardContent,
+                    onClick = {
+                        action(
+                            LyricsPageAction.OnChangeSelectedLines(
+                                updateSelectedLines(
+                                    state.selectedLines,
+                                    it.key,
+                                    it.value,
+                                    state.maxLines,
                                 )
                             )
+                        )
 
-                            if (!isSelected) {
-                                hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-                            }
-                        },
-                    )
-                }
+                        if (!isSelected) {
+                            hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                        }
+                    },
+                )
             }
         } else {
             when (state.source) {
                 Sources.GENIUS -> {
-                    item {
-                        // start scraping
-                        LaunchedEffect(Unit) {
-                            action(LyricsPageAction.OnScrapeGeniusLyrics(song.id, song.sourceUrl))
-                        }
-
+                    item(key = "genius_empty", contentType = "empty_state") {
                         AnimatedContent(targetState = state.scraping) {
                             Column(
                                 modifier = Modifier.fillMaxWidth(),
@@ -213,7 +220,7 @@ fun PlainLyrics(
                 }
 
                 Sources.LRCLIB -> {
-                    item {
+                    item(key = "lrclib_empty", contentType = "empty_state") {
                         Column(
                             modifier = Modifier.fillMaxWidth(),
                             horizontalAlignment = Alignment.CenterHorizontally,
@@ -236,7 +243,7 @@ fun PlainLyrics(
         }
 
         // Bottom Actions Row
-        item {
+        item(key = "bottom_actions", contentType = "actions") {
             Row(
                 modifier = Modifier.padding(vertical = 100.dp).fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceEvenly,

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/SyllableSyncedLyrics.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/SyllableSyncedLyrics.kt
@@ -76,6 +76,7 @@ import com.shub39.rush.presentation.toAlignment
 import com.shub39.rush.presentation.toArrangement
 import com.shub39.rush.presentation.toTextAlignment
 import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 fun SyllableSyncedLyrics(
@@ -522,7 +523,7 @@ fun SyllableSyncedLyricsPreview() {
         while (true) {
             val elapsed = System.currentTimeMillis() - startTime
             position = elapsed % 30000
-            delay(16)
+            delay(16.milliseconds)
         }
     }
 

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/SyllableSyncedLyrics.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/SyllableSyncedLyrics.kt
@@ -17,30 +17,25 @@
 package com.shub39.rush.presentation.lyrics.component
 
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.collectIsDraggedAsState
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
-import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -58,8 +53,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -78,12 +71,12 @@ import com.shub39.rush.presentation.lyrics.LyricsState
 import com.shub39.rush.presentation.lyrics.PlaybackInfo
 import com.shub39.rush.presentation.lyrics.PlayingSong
 import com.shub39.rush.presentation.lyrics.TextPrefs
+import com.shub39.rush.presentation.lyrics.rememberLineProgress
 import com.shub39.rush.presentation.lyrics.toTransformOrigin
 import com.shub39.rush.presentation.theme.flexFontEmphasis
 import com.shub39.rush.presentation.toAlignment
 import com.shub39.rush.presentation.toArrangement
 import com.shub39.rush.presentation.toTextAlignment
-import kotlin.math.abs
 import kotlinx.coroutines.delay
 
 @Composable
@@ -95,127 +88,84 @@ fun SyllableSyncedLyrics(
     action: (LyricsPageAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val isUserScrolling by lazyListState.interactionSource.collectIsDraggedAsState()
-    var pauseAutoScroll by remember { mutableStateOf(false) }
-
-    val itemHeights = remember { mutableStateMapOf<Int, Int>() }
-
-    val ttmlLyrics = (state.lyricsState as? LyricsState.Loaded)?.song?.ttmlLyrics ?: return
+    val song = (state.lyricsState as? LyricsState.Loaded)?.song ?: return
+    val ttmlLyrics = song.ttmlLyrics ?: return
 
     val currentPlayingIndex =
-        ttmlLyrics.indexOfLast { (it.startTime * 1000).toLong() <= playbackInfo.position }
-
-    // updater for synced lyrics
-    LaunchedEffect(currentPlayingIndex, pauseAutoScroll) {
-        if (currentPlayingIndex >= 0 && !pauseAutoScroll) {
-            val viewportHeight =
-                lazyListState.layoutInfo.viewportEndOffset -
-                    lazyListState.layoutInfo.viewportStartOffset
-            val itemHeight = itemHeights[currentPlayingIndex] ?: 0
-            val centerOffset = (viewportHeight / 4) - (itemHeight / 2)
-            lazyListState.animateScrollToItem(
-                index = currentPlayingIndex,
-                scrollOffset = -centerOffset,
-            )
+        remember(playbackInfo.position, ttmlLyrics) {
+            ttmlLyrics.indexOfLast { (it.startTime * 1000).toLong() <= playbackInfo.position }
         }
-    }
 
-    // scroll interaction
-    LaunchedEffect(isUserScrolling) {
-        if (!isUserScrolling) {
-            delay(3000)
-            pauseAutoScroll = false
-        } else {
-            pauseAutoScroll = true
+    val romanizedTtml =
+        remember(state.romanizationEnabled, song) {
+            if (state.romanizationEnabled) song.romanizedTtmlLyrics else emptyMap()
         }
-    }
 
-    // Synced Lyrics
-    LazyColumn(
+    BaseSyncedLyrics(
+        state = state,
+        playbackInfo = playbackInfo,
+        lazyListState = lazyListState,
+        items = ttmlLyrics,
+        currentPlayingIndex = currentPlayingIndex,
+        itemKey = { _, line -> line.startTime },
         modifier = modifier,
-        contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 64.dp, bottom = 256.dp),
-        verticalArrangement =
-            Arrangement.spacedBy(
-                with(LocalDensity.current) { state.textPrefs.lineHeight.sp.toDp() / 2 }
-            ),
-        state = lazyListState,
-    ) {
-        itemsIndexed(items = ttmlLyrics, key = { it, _ -> it }) { index, line ->
-            val currentTime = playbackInfo.position
-            val isCurrent = index == currentPlayingIndex
+    ) { index, line, blur ->
+        val currentTime = playbackInfo.position
+        val isCurrent = index == currentPlayingIndex
 
-            val nextTime = ttmlLyrics.getOrNull(index + 1)?.startTime
-            val progress =
-                nextTime?.let { nt ->
-                    val startTime = line.startTime
-                    val currentSecs = currentTime / 1000.0
-                    val denom = (nt - startTime).toFloat()
-                    if (denom <= 0f) 1f
-                    else ((currentSecs - startTime).toFloat() / denom).coerceIn(0f, 1f)
-                } ?: 1f
+        val nextTime = ttmlLyrics.getOrNull(index + 1)?.startTime
+        val progress = rememberLineProgress(
+            currentTime = currentTime,
+            startTime = line.startTime,
+            nextTime = nextTime
+        )
 
-            val animatedProgress by
-                animateFloatAsState(
-                    targetValue = progress,
-                    animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-                    label = "loadingProgress",
-                )
+        val animatedProgress by
+        animateFloatAsState(
+            targetValue = progress,
+            animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+            label = "loadingProgress",
+        )
 
-            val underTextAlpha by
-                animateFloatAsState(
-                    targetValue = if (isCurrent) 0.5f else 0.2f,
-                    animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-                    label = "underTextAlpha",
-                )
+        val underTextAlpha by
+        animateFloatAsState(
+            targetValue = if (isCurrent) 0.5f else 0.2f,
+            animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+            label = "underTextAlpha",
+        )
 
-            val blur by
-                animateDpAsState(
-                    targetValue =
-                        if (!state.blurSyncedLyrics || pauseAutoScroll) 0.dp
-                        else (abs(index - currentPlayingIndex) * 3).coerceIn(0..10).dp,
-                    animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-                )
+        val scale by
+        animateFloatAsState(
+            targetValue = if (isCurrent) 1f else 0.8f,
+            animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+            label = "scale",
+        )
 
-            val scale by
-                animateFloatAsState(
-                    targetValue = if (isCurrent) 1f else 0.8f,
-                    animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
-                )
+        val textColor by
+        animateColorAsState(
+            targetValue =
+                when {
+                    (line.startTime * 1000).toLong() <= currentTime -> cardContent
+                    else -> cardContent.copy(0.3f)
+                },
+            animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+            label = "textColor",
+        )
 
-            val textColor by
-                animateColorAsState(
-                    targetValue =
-                        when {
-                            (line.startTime * 1000).toLong() <= currentTime -> cardContent
-                            else -> cardContent.copy(0.3f)
-                        },
-                    animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-                    label = "textColor",
-                )
-
-            SyllableLine(
-                textPrefs = state.textPrefs,
-                blur = blur,
-                action = action,
-                line = line,
-                romanizedText =
-                    if (state.romanizationEnabled)
-                        state.lyricsState.song.romanizedTtmlLyrics[line.startTime]
-                    else null,
-                textColor = textColor,
-                scale = scale,
-                currentTime = currentTime,
-                animatedProgress = animatedProgress,
-                underTextAlpha = underTextAlpha,
-                isCurrent = isCurrent,
-                expressiveSyllables = state.expressiveSyllables,
-                modifier =
-                    Modifier.onGloballyPositioned { layoutCoordinates ->
-                        val height = layoutCoordinates.size.height
-                        itemHeights[index] = height
-                    },
-            )
-        }
+        SyllableLine(
+            textPrefs = state.textPrefs,
+            blur = blur,
+            action = action,
+            line = line,
+            romanizedText = romanizedTtml[line.startTime],
+            textColor = textColor,
+            scale = scale,
+            currentTime = currentTime,
+            animatedProgress = animatedProgress,
+            underTextAlpha = underTextAlpha,
+            isCurrent = isCurrent,
+            expressiveSyllables = state.expressiveSyllables,
+        )
     }
 }
 
@@ -243,7 +193,8 @@ fun SyllableLine(
     ) {
         Box(
             modifier =
-                Modifier.graphicsLayer {
+                Modifier
+                    .graphicsLayer {
                         scaleX = scale
                         scaleY = scale
                         transformOrigin = textPrefs.lyricsAlignment.toTransformOrigin()
@@ -348,43 +299,58 @@ private fun SyllableWord(
             }
         }
 
-    val wordProgress =
-        if (currentTime >= wordEndTimeMs) 1f
-        else if (currentTime < wordStartTimeMs) 0f
-        else (currentTime - wordStartTimeMs).toFloat() / duration
+    val wordProgress by remember(currentTime, wordStartTimeMs, wordEndTimeMs) {
+        mutableFloatStateOf(
+            when {
+                currentTime < wordStartTimeMs -> 0f
+                currentTime > wordEndTimeMs -> 1f
+                else -> (currentTime - wordStartTimeMs).toFloat() / duration
+            }
+        )
+    }
 
     val animatedProgress by
-        animateFloatAsState(
-            targetValue = wordProgress,
-            animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
-            label = "wordProgress",
-        )
+    animateFloatAsState(
+        targetValue = wordProgress,
+        animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+        label = "wordProgress",
+    )
 
     val currentWeight =
         remember(animatedProgress, maxWordWeight) {
-                ((200 + (animatedProgress * (maxWordWeight - 200))) / 10).toInt() * 10
-            }
-            .coerceIn(200, maxWordWeight)
+            mutableIntStateOf(
+                (((200 + (animatedProgress * (maxWordWeight - 200))) / 10).toInt() * 10).coerceIn(
+                    200,
+                    maxWordWeight
+                )
+            )
+
+        }
+
     val currentWidth =
         remember(animatedProgress, maxWordWidth) {
-                ((100f + (animatedProgress * (maxWordWidth - 100f))) * 2).toInt() / 2f
-            }
-            .coerceIn(100f, maxWordWidth)
+            mutableFloatStateOf(
+                (((100f + (animatedProgress * (maxWordWidth - 100f))) * 2).toInt() / 2f).coerceIn(
+                    100f,
+                    maxWordWidth
+                )
+            )
+        }
 
     // word highlighting design
     val isHighlighted = currentTime >= wordStartTimeMs
     val wordScale by
-        animateFloatAsState(
-            targetValue = if (isHighlighted || scale != 1f) 1f else 0.95f,
-            animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
-            label = "wordScale",
-        )
+    animateFloatAsState(
+        targetValue = if (isHighlighted || scale != 1f) 1f else 0.95f,
+        animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+        label = "wordScale",
+    )
     val glowAlpha by
-        animateFloatAsState(
-            targetValue = if (isHighlighted) 2f else 0f,
-            animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-            label = "glowAlpha",
-        )
+    animateFloatAsState(
+        targetValue = if (isHighlighted) 2f else 0f,
+        animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+        label = "glowAlpha",
+    )
 
     val textStyle =
         remember(currentWeight, currentWidth, textPrefs, expressiveSyllables) {
@@ -396,14 +362,21 @@ private fun SyllableWord(
                 fontWeight = FontWeight.Bold,
                 fontFamily =
                     if (expressiveSyllables) {
-                        flexFontEmphasis(fontWeight = currentWeight, fontWidth = currentWidth)
+                        flexFontEmphasis(
+                            fontWeight = currentWeight.intValue,
+                            fontWidth = currentWidth.floatValue
+                        )
                     } else {
                         fontFamily
                     },
             )
         }
 
-    Box(modifier = Modifier.padding(horizontal = 4.dp).scale(wordScale)) {
+    Box(
+        modifier = Modifier
+            .padding(horizontal = 4.dp)
+            .graphicsLayer { scaleX = wordScale; scaleY = wordScale }
+    ) {
         // Ghost text for layout consistency
         Text(
             text = word.text,
@@ -430,7 +403,8 @@ private fun SyllableWord(
             style = textStyle,
             color = textColor.copy(alpha = underTextAlpha),
             modifier =
-                Modifier.matchParentSize()
+                Modifier
+                    .matchParentSize()
                     .blur(radius = glowAlpha.dp, edgeTreatment = BlurredEdgeTreatment.Unbounded),
         )
 
@@ -440,7 +414,8 @@ private fun SyllableWord(
             style = textStyle,
             color = textColor,
             modifier =
-                Modifier.matchParentSize()
+                Modifier
+                    .matchParentSize()
                     .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
                     .drawWithContent {
                         if (animatedProgress > 0f) {
@@ -453,7 +428,7 @@ private fun SyllableWord(
                                         Brush.horizontalGradient(
                                             0f to Color.Black,
                                             ((x - feather) / size.width).coerceIn(0f, 1f) to
-                                                Color.Black,
+                                                    Color.Black,
                                             (x / size.width).coerceIn(0f, 1f) to Color.Transparent,
                                             1f to Color.Transparent,
                                         ),

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/SyllableSyncedLyrics.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/SyllableSyncedLyrics.kt
@@ -297,15 +297,13 @@ private fun SyllableWord(
             }
         }
 
-    val wordProgress by
+    val wordProgress =
         remember(currentTime, wordStartTimeMs, wordEndTimeMs) {
-            mutableFloatStateOf(
-                when {
-                    currentTime < wordStartTimeMs -> 0f
-                    currentTime > wordEndTimeMs -> 1f
-                    else -> (currentTime - wordStartTimeMs).toFloat() / duration
-                }
-            )
+            when {
+                currentTime < wordStartTimeMs -> 0f
+                currentTime > wordEndTimeMs -> 1f
+                else -> (currentTime - wordStartTimeMs).toFloat() / duration
+            }
         }
 
     val animatedProgress by

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/SyllableSyncedLyrics.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/SyllableSyncedLyrics.kt
@@ -112,43 +112,44 @@ fun SyllableSyncedLyrics(
         val isCurrent = index == currentPlayingIndex
 
         val nextTime = ttmlLyrics.getOrNull(index + 1)?.startTime
-        val progress = rememberLineProgress(
-            currentTime = currentTime,
-            startTime = line.startTime,
-            nextTime = nextTime
-        )
+        val progress =
+            rememberLineProgress(
+                currentTime = currentTime,
+                startTime = line.startTime,
+                nextTime = nextTime,
+            )
 
         val animatedProgress by
-        animateFloatAsState(
-            targetValue = progress,
-            animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-            label = "loadingProgress",
-        )
+            animateFloatAsState(
+                targetValue = progress,
+                animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+                label = "loadingProgress",
+            )
 
         val underTextAlpha by
-        animateFloatAsState(
-            targetValue = if (isCurrent) 0.5f else 0.2f,
-            animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-            label = "underTextAlpha",
-        )
+            animateFloatAsState(
+                targetValue = if (isCurrent) 0.5f else 0.2f,
+                animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+                label = "underTextAlpha",
+            )
 
         val scale by
-        animateFloatAsState(
-            targetValue = if (isCurrent) 1f else 0.8f,
-            animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
-            label = "scale",
-        )
+            animateFloatAsState(
+                targetValue = if (isCurrent) 1f else 0.8f,
+                animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+                label = "scale",
+            )
 
         val textColor by
-        animateColorAsState(
-            targetValue =
-                when {
-                    (line.startTime * 1000).toLong() <= currentTime -> cardContent
-                    else -> cardContent.copy(0.3f)
-                },
-            animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-            label = "textColor",
-        )
+            animateColorAsState(
+                targetValue =
+                    when {
+                        (line.startTime * 1000).toLong() <= currentTime -> cardContent
+                        else -> cardContent.copy(0.3f)
+                    },
+                animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+                label = "textColor",
+            )
 
         SyllableLine(
             textPrefs = state.textPrefs,
@@ -191,8 +192,7 @@ fun SyllableLine(
     ) {
         Box(
             modifier =
-                Modifier
-                    .graphicsLayer {
+                Modifier.graphicsLayer {
                         scaleX = scale
                         scaleY = scale
                         transformOrigin = textPrefs.lyricsAlignment.toTransformOrigin()
@@ -297,32 +297,32 @@ private fun SyllableWord(
             }
         }
 
-    val wordProgress by remember(currentTime, wordStartTimeMs, wordEndTimeMs) {
-        mutableFloatStateOf(
-            when {
-                currentTime < wordStartTimeMs -> 0f
-                currentTime > wordEndTimeMs -> 1f
-                else -> (currentTime - wordStartTimeMs).toFloat() / duration
-            }
-        )
-    }
+    val wordProgress by
+        remember(currentTime, wordStartTimeMs, wordEndTimeMs) {
+            mutableFloatStateOf(
+                when {
+                    currentTime < wordStartTimeMs -> 0f
+                    currentTime > wordEndTimeMs -> 1f
+                    else -> (currentTime - wordStartTimeMs).toFloat() / duration
+                }
+            )
+        }
 
     val animatedProgress by
-    animateFloatAsState(
-        targetValue = wordProgress,
-        animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
-        label = "wordProgress",
-    )
+        animateFloatAsState(
+            targetValue = wordProgress,
+            animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+            label = "wordProgress",
+        )
 
     val currentWeight =
         remember(animatedProgress, maxWordWeight) {
             mutableIntStateOf(
                 (((200 + (animatedProgress * (maxWordWeight - 200))) / 10).toInt() * 10).coerceIn(
                     200,
-                    maxWordWeight
+                    maxWordWeight,
                 )
             )
-
         }
 
     val currentWidth =
@@ -330,7 +330,7 @@ private fun SyllableWord(
             mutableFloatStateOf(
                 (((100f + (animatedProgress * (maxWordWidth - 100f))) * 2).toInt() / 2f).coerceIn(
                     100f,
-                    maxWordWidth
+                    maxWordWidth,
                 )
             )
         }
@@ -338,17 +338,17 @@ private fun SyllableWord(
     // word highlighting design
     val isHighlighted = currentTime >= wordStartTimeMs
     val wordScale by
-    animateFloatAsState(
-        targetValue = if (isHighlighted || scale != 1f) 1f else 0.95f,
-        animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
-        label = "wordScale",
-    )
+        animateFloatAsState(
+            targetValue = if (isHighlighted || scale != 1f) 1f else 0.95f,
+            animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+            label = "wordScale",
+        )
     val glowAlpha by
-    animateFloatAsState(
-        targetValue = if (isHighlighted) 2f else 0f,
-        animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-        label = "glowAlpha",
-    )
+        animateFloatAsState(
+            targetValue = if (isHighlighted) 2f else 0f,
+            animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+            label = "glowAlpha",
+        )
 
     val textStyle =
         remember(currentWeight, currentWidth, textPrefs, expressiveSyllables) {
@@ -362,7 +362,7 @@ private fun SyllableWord(
                     if (expressiveSyllables) {
                         flexFontEmphasis(
                             fontWeight = currentWeight.intValue,
-                            fontWidth = currentWidth.floatValue
+                            fontWidth = currentWidth.floatValue,
                         )
                     } else {
                         fontFamily
@@ -371,9 +371,11 @@ private fun SyllableWord(
         }
 
     Box(
-        modifier = Modifier
-            .padding(horizontal = 4.dp)
-            .graphicsLayer { scaleX = wordScale; scaleY = wordScale }
+        modifier =
+            Modifier.padding(horizontal = 4.dp).graphicsLayer {
+                scaleX = wordScale
+                scaleY = wordScale
+            }
     ) {
         // Ghost text for layout consistency
         Text(
@@ -401,8 +403,7 @@ private fun SyllableWord(
             style = textStyle,
             color = textColor.copy(alpha = underTextAlpha),
             modifier =
-                Modifier
-                    .matchParentSize()
+                Modifier.matchParentSize()
                     .blur(radius = glowAlpha.dp, edgeTreatment = BlurredEdgeTreatment.Unbounded),
         )
 
@@ -412,8 +413,7 @@ private fun SyllableWord(
             style = textStyle,
             color = textColor,
             modifier =
-                Modifier
-                    .matchParentSize()
+                Modifier.matchParentSize()
                     .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
                     .drawWithContent {
                         if (animatedProgress > 0f) {
@@ -426,7 +426,7 @@ private fun SyllableWord(
                                         Brush.horizontalGradient(
                                             0f to Color.Black,
                                             ((x - feather) / size.width).coerceIn(0f, 1f) to
-                                                    Color.Black,
+                                                Color.Black,
                                             (x / size.width).coerceIn(0f, 1f) to Color.Transparent,
                                             1f to Color.Transparent,
                                         ),

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/SyllableSyncedLyrics.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/SyllableSyncedLyrics.kt
@@ -75,8 +75,8 @@ import com.shub39.rush.presentation.theme.flexFontEmphasis
 import com.shub39.rush.presentation.toAlignment
 import com.shub39.rush.presentation.toArrangement
 import com.shub39.rush.presentation.toTextAlignment
-import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
 
 @Composable
 fun SyllableSyncedLyrics(

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/SyllableSyncedLyrics.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/SyllableSyncedLyrics.kt
@@ -36,7 +36,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -46,7 +45,6 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsCustomisationPage.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsCustomisationPage.kt
@@ -53,7 +53,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -166,8 +165,8 @@ fun LyricsCustomisationsPage(
                         .animateContentSize(),
                 contentPadding =
                     PaddingValues(
-                        start = paddingValues.calculateLeftPadding(LocalLayoutDirection.current),
-                        end = paddingValues.calculateRightPadding(LocalLayoutDirection.current),
+                        start = 16.dp,
+                        end = 16.dp,
                         bottom = paddingValues.calculateBottomPadding() + 60.dp,
                     ),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
@@ -263,11 +262,7 @@ fun LyricsCustomisationsPage(
         ) { paddingValues ->
             Row(
                 modifier =
-                    Modifier.padding(
-                            start =
-                                paddingValues.calculateLeftPadding(LocalLayoutDirection.current),
-                            end = paddingValues.calculateRightPadding(LocalLayoutDirection.current),
-                        )
+                    Modifier.padding(paddingValues)
                         .fillMaxSize(),
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
             ) {
@@ -275,11 +270,7 @@ fun LyricsCustomisationsPage(
                     modifier =
                         Modifier.weight(1f)
                             .verticalScroll(rememberScrollState())
-                            .padding(
-                                top = paddingValues.calculateTopPadding() + 16.dp,
-                                start = 16.dp,
-                                bottom = paddingValues.calculateBottomPadding() + 16.dp,
-                            ),
+                            .padding(16.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     if (notificationAccess) {
@@ -321,9 +312,9 @@ fun LyricsCustomisationsPage(
                     modifier = Modifier.weight(1f).fillMaxHeight(),
                     contentPadding =
                         PaddingValues(
-                            top = paddingValues.calculateTopPadding() + 16.dp,
+                            top = 16.dp,
                             end = 16.dp,
-                            bottom = paddingValues.calculateBottomPadding() + 60.dp,
+                            bottom = 60.dp,
                         ),
                     verticalArrangement = Arrangement.spacedBy(16.dp),
                 ) {

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsCustomisationPage.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsCustomisationPage.kt
@@ -163,14 +163,11 @@ fun LyricsCustomisationsPage(
         ) { paddingValues ->
             LazyColumn(
                 modifier =
-                    Modifier
-                        .padding(top = paddingValues.calculateTopPadding())
+                    Modifier.padding(top = paddingValues.calculateTopPadding())
                         .fillMaxSize()
                         .animateContentSize(),
                 contentPadding =
-                    PaddingValues(
-                        bottom = paddingValues.calculateBottomPadding() + 60.dp,
-                    ),
+                    PaddingValues(bottom = paddingValues.calculateBottomPadding() + 60.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 stickyHeader {
@@ -183,18 +180,14 @@ fun LyricsCustomisationsPage(
                     ) {
                         if (notificationAccess) {
                             Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 16.dp),
+                                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
                                 horizontalArrangement =
                                     Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween),
                             ) {
                                 ToggleButton(
                                     checked = !isShowingSynced,
                                     onCheckedChange = { isShowingSynced = false },
-                                    modifier = Modifier
-                                        .weight(1f)
-                                        .padding(vertical = 8.dp),
+                                    modifier = Modifier.weight(1f).padding(vertical = 8.dp),
                                 ) {
                                     Text(text = stringResource(R.string.plain_lyrics))
                                 }
@@ -202,9 +195,7 @@ fun LyricsCustomisationsPage(
                                 ToggleButton(
                                     checked = isShowingSynced,
                                     onCheckedChange = { isShowingSynced = true },
-                                    modifier = Modifier
-                                        .weight(1f)
-                                        .padding(vertical = 8.dp),
+                                    modifier = Modifier.weight(1f).padding(vertical = 8.dp),
                                 ) {
                                     Text(text = stringResource(R.string.synced_lyrics))
                                 }
@@ -269,39 +260,35 @@ fun LyricsCustomisationsPage(
             modifier = modifier,
         ) { paddingValues ->
             Row(
-                modifier = Modifier
-                    .padding(
-                        start = paddingValues.calculateLeftPadding(LocalLayoutDirection.current),
-                        end = paddingValues.calculateRightPadding(LocalLayoutDirection.current),
-                    )
-                    .fillMaxSize(),
+                modifier =
+                    Modifier.padding(
+                            start =
+                                paddingValues.calculateLeftPadding(LocalLayoutDirection.current),
+                            end = paddingValues.calculateRightPadding(LocalLayoutDirection.current),
+                        )
+                        .fillMaxSize(),
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 Column(
                     modifier =
-                        Modifier
-                            .weight(1f)
+                        Modifier.weight(1f)
                             .verticalScroll(rememberScrollState())
                             .padding(
                                 top = paddingValues.calculateTopPadding() + 16.dp,
                                 start = 16.dp,
-                                bottom = 16.dp
+                                bottom = 16.dp,
                             ),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     if (notificationAccess) {
                         Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 16.dp),
+                            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
                             ToggleButton(
                                 checked = !isShowingSynced,
                                 onCheckedChange = { isShowingSynced = false },
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .padding(vertical = 8.dp),
+                                modifier = Modifier.weight(1f).padding(vertical = 8.dp),
                             ) {
                                 Text(text = stringResource(R.string.plain_lyrics))
                             }
@@ -309,9 +296,7 @@ fun LyricsCustomisationsPage(
                             ToggleButton(
                                 checked = isShowingSynced,
                                 onCheckedChange = { isShowingSynced = true },
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .padding(vertical = 8.dp),
+                                modifier = Modifier.weight(1f).padding(vertical = 8.dp),
                             ) {
                                 Text(text = stringResource(R.string.synced_lyrics))
                             }
@@ -331,14 +316,13 @@ fun LyricsCustomisationsPage(
                 }
 
                 LazyColumn(
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxHeight(),
-                    contentPadding = PaddingValues(
-                        top = paddingValues.calculateTopPadding() + 16.dp,
-                        end = 16.dp,
-                        bottom = paddingValues.calculateBottomPadding() + 60.dp,
-                    ),
+                    modifier = Modifier.weight(1f).fillMaxHeight(),
+                    contentPadding =
+                        PaddingValues(
+                            top = paddingValues.calculateTopPadding() + 16.dp,
+                            end = 16.dp,
+                            bottom = paddingValues.calculateBottomPadding() + 60.dp,
+                        ),
                     verticalArrangement = Arrangement.spacedBy(16.dp),
                 ) {
                     lyricsCustomisationSettings(

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsCustomisationPage.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsCustomisationPage.kt
@@ -53,10 +53,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.dp
 import com.shub39.rush.R
@@ -160,13 +163,12 @@ fun LyricsCustomisationsPage(
         ) { paddingValues ->
             LazyColumn(
                 modifier =
-                    Modifier.padding(top = paddingValues.calculateTopPadding())
+                    Modifier
+                        .padding(top = paddingValues.calculateTopPadding())
                         .fillMaxSize()
                         .animateContentSize(),
                 contentPadding =
                     PaddingValues(
-                        start = 16.dp,
-                        end = 16.dp,
                         bottom = paddingValues.calculateBottomPadding() + 60.dp,
                     ),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
@@ -181,14 +183,18 @@ fun LyricsCustomisationsPage(
                     ) {
                         if (notificationAccess) {
                             Row(
-                                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp),
                                 horizontalArrangement =
                                     Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween),
                             ) {
                                 ToggleButton(
                                     checked = !isShowingSynced,
                                     onCheckedChange = { isShowingSynced = false },
-                                    modifier = Modifier.weight(1f).padding(vertical = 8.dp),
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .padding(vertical = 8.dp),
                                 ) {
                                     Text(text = stringResource(R.string.plain_lyrics))
                                 }
@@ -196,7 +202,9 @@ fun LyricsCustomisationsPage(
                                 ToggleButton(
                                     checked = isShowingSynced,
                                     onCheckedChange = { isShowingSynced = true },
-                                    modifier = Modifier.weight(1f).padding(vertical = 8.dp),
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .padding(vertical = 8.dp),
                                 ) {
                                     Text(text = stringResource(R.string.synced_lyrics))
                                 }
@@ -261,23 +269,39 @@ fun LyricsCustomisationsPage(
             modifier = modifier,
         ) { paddingValues ->
             Row(
-                modifier = Modifier.padding(paddingValues).fillMaxSize(),
+                modifier = Modifier
+                    .padding(
+                        start = paddingValues.calculateLeftPadding(LocalLayoutDirection.current),
+                        end = paddingValues.calculateRightPadding(LocalLayoutDirection.current),
+                    )
+                    .fillMaxSize(),
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 Column(
                     modifier =
-                        Modifier.weight(1f).verticalScroll(rememberScrollState()).padding(16.dp),
+                        Modifier
+                            .weight(1f)
+                            .verticalScroll(rememberScrollState())
+                            .padding(
+                                top = paddingValues.calculateTopPadding() + 16.dp,
+                                start = 16.dp,
+                                bottom = 16.dp
+                            ),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     if (notificationAccess) {
                         Row(
-                            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp),
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
                             ToggleButton(
                                 checked = !isShowingSynced,
                                 onCheckedChange = { isShowingSynced = false },
-                                modifier = Modifier.weight(1f).padding(vertical = 8.dp),
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(vertical = 8.dp),
                             ) {
                                 Text(text = stringResource(R.string.plain_lyrics))
                             }
@@ -285,7 +309,9 @@ fun LyricsCustomisationsPage(
                             ToggleButton(
                                 checked = isShowingSynced,
                                 onCheckedChange = { isShowingSynced = true },
-                                modifier = Modifier.weight(1f).padding(vertical = 8.dp),
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .padding(vertical = 8.dp),
                             ) {
                                 Text(text = stringResource(R.string.synced_lyrics))
                             }
@@ -305,8 +331,14 @@ fun LyricsCustomisationsPage(
                 }
 
                 LazyColumn(
-                    modifier = Modifier.weight(1f).fillMaxHeight(),
-                    contentPadding = PaddingValues(top = 16.dp, end = 16.dp, bottom = 60.dp),
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight(),
+                    contentPadding = PaddingValues(
+                        top = paddingValues.calculateTopPadding() + 16.dp,
+                        end = 16.dp,
+                        bottom = paddingValues.calculateBottomPadding() + 60.dp,
+                    ),
                     verticalArrangement = Arrangement.spacedBy(16.dp),
                 ) {
                     lyricsCustomisationSettings(
@@ -370,7 +402,8 @@ private fun AudioPermissionDialog(
 }
 
 @PreviewWrapper(RushPreviewWrapper::class)
-@Preview
+@PreviewLightDark
+@PreviewScreenSizes
 @Composable
 private fun Preview() {
     var state by remember {

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsCustomisationPage.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsCustomisationPage.kt
@@ -261,16 +261,12 @@ fun LyricsCustomisationsPage(
             modifier = modifier,
         ) { paddingValues ->
             Row(
-                modifier =
-                    Modifier.padding(paddingValues)
-                        .fillMaxSize(),
+                modifier = Modifier.padding(paddingValues).fillMaxSize(),
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 Column(
                     modifier =
-                        Modifier.weight(1f)
-                            .verticalScroll(rememberScrollState())
-                            .padding(16.dp),
+                        Modifier.weight(1f).verticalScroll(rememberScrollState()).padding(16.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     if (notificationAccess) {
@@ -310,12 +306,7 @@ fun LyricsCustomisationsPage(
 
                 LazyColumn(
                     modifier = Modifier.weight(1f).fillMaxHeight(),
-                    contentPadding =
-                        PaddingValues(
-                            top = 16.dp,
-                            end = 16.dp,
-                            bottom = 60.dp,
-                        ),
+                    contentPadding = PaddingValues(top = 16.dp, end = 16.dp, bottom = 60.dp),
                     verticalArrangement = Arrangement.spacedBy(16.dp),
                 ) {
                     lyricsCustomisationSettings(

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsPage.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsPage.kt
@@ -140,7 +140,8 @@ fun LyricsPage(
             animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
         )
 
-    val glowCardBackground by remember { mutableFloatStateOf((24 * glowMultiplier)) }
+    val glowCardBackground by
+        remember(glowMultiplier) { mutableFloatStateOf((24 * glowMultiplier)) }
 
     val top by remember { derivedStateOf { lazyListState.firstVisibleItemIndex } }
 

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsPage.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsPage.kt
@@ -74,6 +74,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.dp
 import com.shub39.rush.R
@@ -116,6 +117,7 @@ import com.shub39.rush.presentation.theme.flexFontRounded
 import com.shub39.rush.presentation.toAlignment
 import io.gitlab.bpavuk.viz.VisualizerData
 import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.milliseconds
 
 @Composable
 fun LyricsPage(
@@ -170,7 +172,7 @@ fun LyricsPage(
 
     LaunchedEffect(songId) {
         if (songId == null) return@LaunchedEffect
-        delay(100)
+        delay(100.milliseconds)
         lazyListState.animateScrollToItem(0)
         action(LyricsPageAction.OnSetPosition(0))
     }
@@ -349,11 +351,25 @@ fun LyricsPage(
                                                 .safeDrawingPadding()
                                                 .padding(horizontal = 16.dp),
                                         verticalAlignment = Alignment.CenterVertically,
-                                        horizontalArrangement = Arrangement.spacedBy(24.dp),
+                                        horizontalArrangement = Arrangement.spacedBy(16.dp),
                                     ) {
                                         Column(
+                                            modifier = Modifier.animateContentSize()
+                                        ) {
+                                            Actions(
+                                                state = actionsState,
+                                                action = action,
+                                                notificationAccess = notificationAccess,
+                                                cardBackground = cardBackground,
+                                                cardContent = cardContent,
+                                                onShare = onShare,
+                                                onEdit = onNavigateToCustomisations,
+                                            )
+                                        }
+
+                                        Column(
                                             modifier =
-                                                Modifier.widthIn(max = 320.dp).animateContentSize(),
+                                                Modifier.fillMaxWidth(0.3f).animateContentSize(),
                                             horizontalAlignment = Alignment.Start,
                                         ) {
                                             ArtFromUrl(
@@ -385,20 +401,6 @@ fun LyricsPage(
                                                 overflow = TextOverflow.Ellipsis,
                                                 modifier = Modifier.basicMarquee(),
                                             )
-
-                                            Spacer(modifier = Modifier.height(8.dp))
-
-                                            Row {
-                                                Actions(
-                                                    state = actionsState,
-                                                    action = action,
-                                                    notificationAccess = notificationAccess,
-                                                    cardBackground = cardBackground,
-                                                    cardContent = cardContent,
-                                                    onShare = onShare,
-                                                    onEdit = onNavigateToCustomisations,
-                                                )
-                                            }
                                         }
 
                                         if (!state.sync) {
@@ -640,6 +642,7 @@ fun LyricsPage(
 }
 
 @PreviewWrapper(RushPreviewWrapper::class)
+@PreviewScreenSizes
 @Preview(
     device = "spec:width=411dp,height=891dp",
     showSystemUi = false,

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsPage.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsPage.kt
@@ -660,7 +660,7 @@ fun LyricsPage(
     fontScale = 1.0f,
 )
 @Composable
-fun LyricsPagePreview() {
+private fun LyricsPagePreview() {
     LyricsPage(
         onNavigateToCustomisations = {},
         onShare = {},

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsPage.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsPage.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -59,6 +60,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.keepScreenOn
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -74,7 +76,6 @@ import com.shub39.rush.domain.dataclasses.SongUi
 import com.shub39.rush.domain.enums.CardColors
 import com.shub39.rush.domain.enums.LyricsAlignment
 import com.shub39.rush.domain.enums.LyricsBackground
-import com.shub39.rush.presentation.KeepScreenOn
 import com.shub39.rush.presentation.RushPreviewWrapper
 import com.shub39.rush.presentation.audioDependentBackgrounds
 import com.shub39.rush.presentation.component.ArtFromUrl
@@ -92,6 +93,7 @@ import com.shub39.rush.presentation.lyrics.SearchState
 import com.shub39.rush.presentation.lyrics.TextPrefs
 import com.shub39.rush.presentation.lyrics.calculateGlowMultiplier
 import com.shub39.rush.presentation.lyrics.component.Actions
+import com.shub39.rush.presentation.lyrics.component.ActionsState
 import com.shub39.rush.presentation.lyrics.component.ErrorCard
 import com.shub39.rush.presentation.lyrics.component.FetchingCard
 import com.shub39.rush.presentation.lyrics.component.LineSyncedLyrics
@@ -118,30 +120,57 @@ fun LyricsPage(
     notificationAccess: Boolean,
 ) {
     val lazyListState = rememberLazyListState()
-
-    // keeping the screen on
-    KeepScreenOn()
+    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
 
     val (cardBackground, cardContent) = getCardColors(state)
     val (hypnoticColor1, hypnoticColor2) = getHypnoticColors(state)
     val waveColors = getWaveColors(state)
 
     val glowMultiplier by
-        animateFloatAsState(
-            targetValue = calculateGlowMultiplier(waveData),
-            animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
-        )
+    animateFloatAsState(
+        targetValue = calculateGlowMultiplier(waveData),
+        animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+    )
 
     val top by remember { derivedStateOf { lazyListState.firstVisibleItemIndex } }
+    val songId = (state.lyricsState as? LyricsState.Loaded)?.song?.id
+    val loadedSong = (state.lyricsState as? LyricsState.Loaded)?.song
+    val lyricsAlignment =
+        remember(state.textPrefs.lyricsAlignment) {
+            state.textPrefs.lyricsAlignment.toAlignment()
+        }
+    val actionsState =
+        remember(
+            loadedSong,
+            state.selectedLines,
+            state.source,
+            state.syncedAvailable,
+            state.sync,
+            state.autoChange,
+        ) {
+            ActionsState(
+                song = loadedSong,
+                selectedLines = state.selectedLines,
+                source = state.source,
+                syncedAvailable = state.syncedAvailable,
+                sync = state.sync,
+                autoChange = state.autoChange,
+            )
+        }
 
-    LaunchedEffect(state.lyricsState) {
+    LaunchedEffect(songId) {
+        if (songId == null) return@LaunchedEffect
         delay(100)
         lazyListState.animateScrollToItem(0)
         action(LyricsPageAction.OnSetPosition(0))
     }
 
     // Content Start
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .keepScreenOn()
+    ) {
         Card(
             modifier = Modifier.fillMaxSize(),
             colors =
@@ -177,8 +206,6 @@ fun LyricsPage(
                     }
 
                     is LyricsState.Loaded -> {
-                        val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
-
                         // Updating colors
                         LaunchedEffect(lyricsState.song.artUrl) {
                             lyricsState.song.artUrl?.let {
@@ -200,56 +227,49 @@ fun LyricsPage(
                             Column {
                                 if (!windowSizeClass.isWidthAtLeastBreakpoint(840)) {
                                     // portrait ui
-                                    Box(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        contentAlignment = Alignment.Center,
-                                    ) {
-                                        Column(modifier = Modifier.align(Alignment.TopCenter)) {
-                                            AnimatedVisibility(
-                                                visible =
-                                                    !state.sync &&
+                                    Column(modifier = Modifier.fillMaxSize()) {
+                                        AnimatedVisibility(
+                                            visible =
+                                                !state.sync &&
                                                         top > 2 &&
                                                         state.lyricsBackground !=
-                                                            LyricsBackground.ALBUM_ART
-                                            ) {
+                                                        LyricsBackground.ALBUM_ART,
+                                        ) {
+                                            ArtFromUrl(
+                                                imageUrl = lyricsState.song.artUrl!!,
+                                                highlightColor = cardContent,
+                                                baseColor = Color.Transparent,
+                                                modifier =
+                                                    Modifier
+                                                        .fillMaxWidth()
+                                                        .height(120.dp)
+                                                        .fadeBottomToTop(),
+                                            )
+                                        }
+
+                                        Column(
+                                            modifier =
+                                                Modifier
+                                                    .fillMaxWidth()
+                                                    .padding(horizontal = 16.dp),
+                                            horizontalAlignment = lyricsAlignment,
+                                        ) {
+                                            Spacer(modifier = Modifier.height(20.dp))
+
+                                            AnimatedVisibility(visible = top <= 2 && !state.sync) {
                                                 ArtFromUrl(
                                                     imageUrl = lyricsState.song.artUrl!!,
                                                     highlightColor = cardContent,
                                                     baseColor = Color.Transparent,
+                                                    contentScale = ContentScale.Crop,
                                                     modifier =
-                                                        Modifier.fillMaxWidth()
-                                                            .height(100.dp)
-                                                            .fadeBottomToTop(),
+                                                        Modifier
+                                                            .size(80.dp)
+                                                            .aspectRatio(1f)
+                                                            .clip(
+                                                                MaterialTheme.shapes.small
+                                                            ),
                                                 )
-                                            }
-                                        }
-
-                                        Column(
-                                            modifier = Modifier.fillMaxWidth(),
-                                            horizontalAlignment =
-                                                state.textPrefs.lyricsAlignment.toAlignment(),
-                                        ) {
-                                            Spacer(modifier = Modifier.height(40.dp))
-
-                                            AnimatedVisibility(visible = top <= 2 && !state.sync) {
-                                                Row(
-                                                    modifier =
-                                                        Modifier.padding(
-                                                            horizontal = 16.dp,
-                                                            vertical = 8.dp,
-                                                        )
-                                                ) {
-                                                    ArtFromUrl(
-                                                        imageUrl = lyricsState.song.artUrl!!,
-                                                        highlightColor = cardContent,
-                                                        baseColor = Color.Transparent,
-                                                        contentScale = ContentScale.Crop,
-                                                        modifier =
-                                                            Modifier.size(80.dp)
-                                                                .aspectRatio(1f)
-                                                                .clip(MaterialTheme.shapes.small),
-                                                    )
-                                                }
                                             }
 
                                             Text(
@@ -261,7 +281,8 @@ fun LyricsPage(
                                                 maxLines = 1,
                                                 overflow = TextOverflow.Ellipsis,
                                                 modifier =
-                                                    Modifier.padding(horizontal = 16.dp)
+                                                    Modifier
+                                                        .padding(top = 8.dp)
                                                         .basicMarquee(),
                                             )
 
@@ -274,19 +295,18 @@ fun LyricsPage(
                                                 fontWeight = FontWeight.Bold,
                                                 maxLines = 1,
                                                 overflow = TextOverflow.Ellipsis,
-                                                modifier =
-                                                    Modifier.padding(horizontal = 16.dp)
-                                                        .basicMarquee(),
+                                                modifier = Modifier.basicMarquee(),
                                             )
 
                                             // Actions Row
                                             Row(
                                                 modifier =
-                                                    Modifier.padding(horizontal = 8.dp)
-                                                        .animateContentSize()
+                                                    Modifier
+                                                        .padding(vertical = 8.dp)
+                                                        .animateContentSize(),
                                             ) {
                                                 Actions(
-                                                    state = state,
+                                                    state = actionsState,
                                                     action = action,
                                                     notificationAccess = notificationAccess,
                                                     cardBackground = cardBackground,
@@ -296,96 +316,6 @@ fun LyricsPage(
                                                 )
                                             }
                                         }
-                                    }
-
-                                    if (!state.sync) {
-                                        PlainLyrics(
-                                            state = state,
-                                            lazyListState = lazyListState,
-                                            cardContent = cardContent,
-                                            action = action,
-                                            modifier = Modifier.weight(1f).fadeTopToBottom(),
-                                        )
-                                    } else if (lyricsState.song.ttmlLyrics != null) {
-                                        SyllableSyncedLyrics(
-                                            state = state,
-                                            playbackInfo = playbackInfo,
-                                            lazyListState = lazyListState,
-                                            cardContent = cardContent,
-                                            action = action,
-                                            modifier = Modifier.weight(1f).fadeTopToBottom(),
-                                        )
-                                    } else if (lyricsState.song.syncedLyrics != null) {
-                                        LineSyncedLyrics(
-                                            state = state,
-                                            playbackInfo = playbackInfo,
-                                            lazyListState = lazyListState,
-                                            cardContent = cardContent,
-                                            action = action,
-                                            modifier = Modifier.weight(1f).fadeTopToBottom(),
-                                        )
-                                    }
-                                } else {
-                                    // landscape UI
-
-                                    Row(
-                                        modifier = Modifier.padding(start = 32.dp).fillMaxWidth(),
-                                        verticalAlignment = Alignment.CenterVertically,
-                                    ) {
-                                        // Actions Row
-                                        Column(modifier = Modifier.animateContentSize()) {
-                                            Actions(
-                                                state = state,
-                                                action = action,
-                                                notificationAccess = notificationAccess,
-                                                cardBackground = cardBackground,
-                                                cardContent = cardContent,
-                                                onShare = onShare,
-                                                onEdit = onNavigateToCustomisations,
-                                            )
-                                        }
-
-                                        Column(modifier = Modifier.fillMaxWidth(0.3f)) {
-                                            Row(
-                                                modifier =
-                                                    Modifier.padding(
-                                                        horizontal = 16.dp,
-                                                        vertical = 8.dp,
-                                                    )
-                                            ) {
-                                                ArtFromUrl(
-                                                    imageUrl = lyricsState.song.artUrl!!,
-                                                    highlightColor = cardContent,
-                                                    baseColor = Color.Transparent,
-                                                    contentScale = ContentScale.Fit,
-                                                    modifier =
-                                                        Modifier.size(100.dp)
-                                                            .clip(MaterialTheme.shapes.small),
-                                                )
-                                            }
-
-                                            Text(
-                                                text = lyricsState.song.title,
-                                                style = MaterialTheme.typography.titleLarge,
-                                                fontWeight = FontWeight.SemiBold,
-                                                maxLines = 1,
-                                                overflow = TextOverflow.Ellipsis,
-                                                modifier =
-                                                    Modifier.padding(horizontal = 16.dp)
-                                                        .basicMarquee(),
-                                            )
-
-                                            Text(
-                                                text = lyricsState.song.artists,
-                                                style = MaterialTheme.typography.bodyMedium,
-                                                fontWeight = FontWeight.Bold,
-                                                maxLines = 1,
-                                                overflow = TextOverflow.Ellipsis,
-                                                modifier =
-                                                    Modifier.padding(horizontal = 16.dp)
-                                                        .basicMarquee(),
-                                            )
-                                        }
 
                                         if (!state.sync) {
                                             PlainLyrics(
@@ -393,7 +323,9 @@ fun LyricsPage(
                                                 lazyListState = lazyListState,
                                                 cardContent = cardContent,
                                                 action = action,
-                                                modifier = Modifier.weight(1f).fadeTopToBottom(),
+                                                modifier = Modifier
+                                                    .weight(1f)
+                                                    .fadeTopToBottom(),
                                             )
                                         } else if (lyricsState.song.ttmlLyrics != null) {
                                             SyllableSyncedLyrics(
@@ -402,7 +334,9 @@ fun LyricsPage(
                                                 lazyListState = lazyListState,
                                                 cardContent = cardContent,
                                                 action = action,
-                                                modifier = Modifier.weight(1f).fadeTopToBottom(),
+                                                modifier = Modifier
+                                                    .weight(1f)
+                                                    .fadeTopToBottom(),
                                             )
                                         } else if (lyricsState.song.syncedLyrics != null) {
                                             LineSyncedLyrics(
@@ -411,7 +345,112 @@ fun LyricsPage(
                                                 lazyListState = lazyListState,
                                                 cardContent = cardContent,
                                                 action = action,
-                                                modifier = Modifier.weight(1f).fadeTopToBottom(),
+                                                modifier = Modifier
+                                                    .weight(1f)
+                                                    .fadeTopToBottom(),
+                                            )
+                                        }
+                                    }
+                                } else {
+                                    // landscape UI
+                                    Row(
+                                        modifier =
+                                            Modifier
+                                                .fillMaxSize()
+                                                .padding(horizontal = 16.dp),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        horizontalArrangement = Arrangement.spacedBy(24.dp),
+                                    ) {
+                                        Column(
+                                            modifier =
+                                                Modifier
+                                                    .widthIn(max = 320.dp)
+                                                    .animateContentSize(),
+                                            horizontalAlignment = Alignment.Start,
+                                        ) {
+                                            ArtFromUrl(
+                                                imageUrl = lyricsState.song.artUrl!!,
+                                                highlightColor = cardContent,
+                                                baseColor = Color.Transparent,
+                                                contentScale = ContentScale.Fit,
+                                                modifier =
+                                                    Modifier
+                                                        .size(120.dp)
+                                                        .clip(MaterialTheme.shapes.small),
+                                            )
+
+                                            Spacer(modifier = Modifier.height(12.dp))
+
+                                            Text(
+                                                text = lyricsState.song.title,
+                                                style = MaterialTheme.typography.titleLarge,
+                                                fontWeight = FontWeight.SemiBold,
+                                                maxLines = 1,
+                                                overflow = TextOverflow.Ellipsis,
+                                                modifier = Modifier.basicMarquee(),
+                                            )
+
+                                            Text(
+                                                text = lyricsState.song.artists,
+                                                style = MaterialTheme.typography.bodyMedium,
+                                                fontWeight = FontWeight.Bold,
+                                                maxLines = 1,
+                                                overflow = TextOverflow.Ellipsis,
+                                                modifier = Modifier.basicMarquee(),
+                                            )
+
+                                            Spacer(modifier = Modifier.height(8.dp))
+
+                                            Row {
+                                                Actions(
+                                                    state = actionsState,
+                                                    action = action,
+                                                    notificationAccess = notificationAccess,
+                                                    cardBackground = cardBackground,
+                                                    cardContent = cardContent,
+                                                    onShare = onShare,
+                                                    onEdit = onNavigateToCustomisations,
+                                                )
+                                            }
+                                        }
+
+                                        if (!state.sync) {
+                                            PlainLyrics(
+                                                state = state,
+                                                lazyListState = lazyListState,
+                                                cardContent = cardContent,
+                                                action = action,
+                                                modifier =
+                                                    Modifier
+                                                        .weight(1f)
+                                                        .fillMaxHeight()
+                                                        .fadeTopToBottom(),
+                                            )
+                                        } else if (lyricsState.song.ttmlLyrics != null) {
+                                            SyllableSyncedLyrics(
+                                                state = state,
+                                                playbackInfo = playbackInfo,
+                                                lazyListState = lazyListState,
+                                                cardContent = cardContent,
+                                                action = action,
+                                                modifier =
+                                                    Modifier
+                                                        .weight(1f)
+                                                        .fillMaxHeight()
+                                                        .fadeTopToBottom(),
+                                            )
+                                        } else if (lyricsState.song.syncedLyrics != null) {
+                                            LineSyncedLyrics(
+                                                state = state,
+                                                playbackInfo = playbackInfo,
+                                                lazyListState = lazyListState,
+                                                cardContent = cardContent,
+                                                action = action,
+                                                modifier =
+                                                    Modifier
+                                                        .weight(1f)
+                                                        .fillMaxHeight()
+                                                        .fadeTopToBottom(),
                                             )
                                         }
                                     }
@@ -424,7 +463,9 @@ fun LyricsPage(
         }
 
         Column(
-            modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 32.dp),
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 32.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
@@ -549,7 +590,8 @@ fun LyricsPage(
                             ),
                         onClick = { action(LyricsPageAction.OnPauseOrResume) },
                         modifier =
-                            Modifier.run {
+                            Modifier
+                                .run {
                                     if (state.lyricsBackground in audioDependentBackgrounds) {
                                         glowBackground(
                                             (24 * glowMultiplier).dp,

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsPage.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsPage.kt
@@ -18,11 +18,11 @@ package com.shub39.rush.presentation.lyrics.section
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.togetherWith
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -135,23 +135,19 @@ fun LyricsPage(
     val waveColors = getWaveColors(state)
 
     val glowMultiplier by
-    animateFloatAsState(
-        targetValue = calculateGlowMultiplier(waveData),
-        animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
-    )
+        animateFloatAsState(
+            targetValue = calculateGlowMultiplier(waveData),
+            animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+        )
 
-    val glowCardBackground by remember {
-        mutableFloatStateOf((24 * glowMultiplier))
-    }
+    val glowCardBackground by remember { mutableFloatStateOf((24 * glowMultiplier)) }
 
     val top by remember { derivedStateOf { lazyListState.firstVisibleItemIndex } }
 
     val songId = (state.lyricsState as? LyricsState.Loaded)?.song?.id
     val loadedSong = (state.lyricsState as? LyricsState.Loaded)?.song
     val lyricsAlignment =
-        remember(state.textPrefs.lyricsAlignment) {
-            state.textPrefs.lyricsAlignment.toAlignment()
-        }
+        remember(state.textPrefs.lyricsAlignment) { state.textPrefs.lyricsAlignment.toAlignment() }
     val actionsState =
         remember(
             loadedSong,
@@ -179,11 +175,7 @@ fun LyricsPage(
     }
 
     // Content Start
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .keepScreenOn()
-    ) {
+    Box(modifier = Modifier.fillMaxSize().keepScreenOn()) {
         Card(
             modifier = Modifier.fillMaxSize(),
             colors =
@@ -244,17 +236,16 @@ fun LyricsPage(
                                         AnimatedVisibility(
                                             visible =
                                                 !state.sync &&
-                                                        top > 2 &&
-                                                        state.lyricsBackground !=
-                                                        LyricsBackground.ALBUM_ART,
+                                                    top > 2 &&
+                                                    state.lyricsBackground !=
+                                                        LyricsBackground.ALBUM_ART
                                         ) {
                                             ArtFromUrl(
                                                 imageUrl = lyricsState.song.artUrl!!,
                                                 highlightColor = cardContent,
                                                 baseColor = Color.Transparent,
                                                 modifier =
-                                                    Modifier
-                                                        .fillMaxWidth()
+                                                    Modifier.fillMaxWidth()
                                                         .height(120.dp)
                                                         .fadeBottomToTop(),
                                             )
@@ -262,8 +253,7 @@ fun LyricsPage(
 
                                         Column(
                                             modifier =
-                                                Modifier
-                                                    .fillMaxWidth()
+                                                Modifier.fillMaxWidth()
                                                     .statusBarsPadding()
                                                     .displayCutoutPadding()
                                                     .padding(horizontal = 16.dp),
@@ -278,32 +268,25 @@ fun LyricsPage(
                                                     baseColor = Color.Transparent,
                                                     contentScale = ContentScale.Crop,
                                                     modifier =
-                                                        Modifier
-                                                            .size(80.dp)
+                                                        Modifier.size(80.dp)
                                                             .aspectRatio(1f)
-                                                            .clip(
-                                                                MaterialTheme.shapes.small
-                                                            ),
+                                                            .clip(MaterialTheme.shapes.small),
                                                 )
                                             }
 
                                             Text(
                                                 text = lyricsState.song.title,
-                                                style =
-                                                    MaterialTheme.typography.headlineMedium,
+                                                style = MaterialTheme.typography.headlineMedium,
                                                 fontFamily = flexFontEmphasis(),
                                                 maxLines = 1,
                                                 overflow = TextOverflow.Ellipsis,
                                                 modifier =
-                                                    Modifier
-                                                        .padding(top = 8.dp)
-                                                        .basicMarquee(),
+                                                    Modifier.padding(top = 8.dp).basicMarquee(),
                                             )
 
                                             Text(
                                                 text = lyricsState.song.artists,
-                                                style =
-                                                    MaterialTheme.typography.titleMedium,
+                                                style = MaterialTheme.typography.titleMedium,
                                                 fontFamily = flexFontRounded(),
                                                 fontWeight = FontWeight.Bold,
                                                 maxLines = 1,
@@ -314,9 +297,8 @@ fun LyricsPage(
                                             // Actions Row
                                             Row(
                                                 modifier =
-                                                    Modifier
-                                                        .padding(vertical = 8.dp)
-                                                        .animateContentSize(),
+                                                    Modifier.padding(vertical = 8.dp)
+                                                        .animateContentSize()
                                             ) {
                                                 Actions(
                                                     state = actionsState,
@@ -336,9 +318,7 @@ fun LyricsPage(
                                                 lazyListState = lazyListState,
                                                 cardContent = cardContent,
                                                 action = action,
-                                                modifier = Modifier
-                                                    .weight(1f)
-                                                    .fadeTopToBottom(),
+                                                modifier = Modifier.weight(1f).fadeTopToBottom(),
                                             )
                                         } else if (lyricsState.song.ttmlLyrics != null) {
                                             SyllableSyncedLyrics(
@@ -347,9 +327,7 @@ fun LyricsPage(
                                                 lazyListState = lazyListState,
                                                 cardContent = cardContent,
                                                 action = action,
-                                                modifier = Modifier
-                                                    .weight(1f)
-                                                    .fadeTopToBottom(),
+                                                modifier = Modifier.weight(1f).fadeTopToBottom(),
                                             )
                                         } else if (lyricsState.song.syncedLyrics != null) {
                                             LineSyncedLyrics(
@@ -358,9 +336,7 @@ fun LyricsPage(
                                                 lazyListState = lazyListState,
                                                 cardContent = cardContent,
                                                 action = action,
-                                                modifier = Modifier
-                                                    .weight(1f)
-                                                    .fadeTopToBottom(),
+                                                modifier = Modifier.weight(1f).fadeTopToBottom(),
                                             )
                                         }
                                     }
@@ -368,8 +344,7 @@ fun LyricsPage(
                                     // landscape UI
                                     Row(
                                         modifier =
-                                            Modifier
-                                                .fillMaxSize()
+                                            Modifier.fillMaxSize()
                                                 .safeDrawingPadding()
                                                 .padding(horizontal = 16.dp),
                                         verticalAlignment = Alignment.CenterVertically,
@@ -377,9 +352,7 @@ fun LyricsPage(
                                     ) {
                                         Column(
                                             modifier =
-                                                Modifier
-                                                    .widthIn(max = 320.dp)
-                                                    .animateContentSize(),
+                                                Modifier.widthIn(max = 320.dp).animateContentSize(),
                                             horizontalAlignment = Alignment.Start,
                                         ) {
                                             ArtFromUrl(
@@ -388,8 +361,7 @@ fun LyricsPage(
                                                 baseColor = Color.Transparent,
                                                 contentScale = ContentScale.Fit,
                                                 modifier =
-                                                    Modifier
-                                                        .size(120.dp)
+                                                    Modifier.size(120.dp)
                                                         .clip(MaterialTheme.shapes.small),
                                             )
 
@@ -435,8 +407,7 @@ fun LyricsPage(
                                                 cardContent = cardContent,
                                                 action = action,
                                                 modifier =
-                                                    Modifier
-                                                        .weight(1f)
+                                                    Modifier.weight(1f)
                                                         .fillMaxHeight()
                                                         .fadeTopToBottom(),
                                             )
@@ -448,8 +419,7 @@ fun LyricsPage(
                                                 cardContent = cardContent,
                                                 action = action,
                                                 modifier =
-                                                    Modifier
-                                                        .weight(1f)
+                                                    Modifier.weight(1f)
                                                         .fillMaxHeight()
                                                         .fadeTopToBottom(),
                                             )
@@ -461,8 +431,7 @@ fun LyricsPage(
                                                 cardContent = cardContent,
                                                 action = action,
                                                 modifier =
-                                                    Modifier
-                                                        .weight(1f)
+                                                    Modifier.weight(1f)
                                                         .fillMaxHeight()
                                                         .fadeTopToBottom(),
                                             )
@@ -477,31 +446,29 @@ fun LyricsPage(
         }
 
         Column(
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .navigationBarsPadding()
-                .padding(bottom = 32.dp),
+            modifier =
+                Modifier.align(Alignment.BottomCenter)
+                    .navigationBarsPadding()
+                    .padding(bottom = 32.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            val autoChangeAlpha by animateFloatAsState(
-                targetValue = if (state.autoChange) 1f else 0f,
-                animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-                label = "autoChangeAlpha"
-            )
+            val autoChangeAlpha by
+                animateFloatAsState(
+                    targetValue = if (state.autoChange) 1f else 0f,
+                    animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+                    label = "autoChangeAlpha",
+                )
 
             if (autoChangeAlpha > 0f) {
                 Box(
-                    modifier = Modifier
-                        .widthIn(max = 150.dp)
-                        .graphicsLayer { alpha = autoChangeAlpha }
+                    modifier =
+                        Modifier.widthIn(max = 150.dp).graphicsLayer { alpha = autoChangeAlpha }
                 ) {
                     AnimatedContent(
                         targetState = state.searchState,
-                        transitionSpec = {
-                            fadeIn() togetherWith fadeOut()
-                        },
-                        label = "searchState"
+                        transitionSpec = { fadeIn() togetherWith fadeOut() },
+                        label = "searchState",
                     ) { searchState ->
                         when (searchState) {
                             SearchState.Idle -> {}
@@ -555,8 +522,7 @@ fun LyricsPage(
                                         Column {
                                             Text(
                                                 text = stringResource(R.string.not_found),
-                                                style =
-                                                    MaterialTheme.typography.bodySmall,
+                                                style = MaterialTheme.typography.bodySmall,
                                                 fontWeight = FontWeight.Bold,
                                                 maxLines = 1,
                                                 overflow = TextOverflow.Ellipsis,
@@ -617,15 +583,10 @@ fun LyricsPage(
                             ),
                         onClick = { action(LyricsPageAction.OnPauseOrResume) },
                         modifier =
-                            Modifier
-                                .conditional(
+                            Modifier.conditional(
                                     state.lyricsBackground in audioDependentBackgrounds
                                 ) {
-                                    glowBackground(
-                                        glowCardBackground.dp,
-                                        CircleShape,
-                                        cardContent,
-                                    )
+                                    glowBackground(glowCardBackground.dp, CircleShape, cardContent)
                                 }
                                 .height(60.dp)
                                 .width(120.dp),

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsPage.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsPage.kt
@@ -29,12 +29,16 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.displayCutoutPadding
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -54,6 +58,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -81,6 +86,7 @@ import com.shub39.rush.presentation.audioDependentBackgrounds
 import com.shub39.rush.presentation.component.ArtFromUrl
 import com.shub39.rush.presentation.component.Empty
 import com.shub39.rush.presentation.component.PageFill
+import com.shub39.rush.presentation.conditional
 import com.shub39.rush.presentation.fadeBottomToTop
 import com.shub39.rush.presentation.fadeTopToBottom
 import com.shub39.rush.presentation.glowBackground
@@ -132,7 +138,12 @@ fun LyricsPage(
         animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
     )
 
+    val glowCardBackground by remember {
+        mutableFloatStateOf((24 * glowMultiplier))
+    }
+
     val top by remember { derivedStateOf { lazyListState.firstVisibleItemIndex } }
+
     val songId = (state.lyricsState as? LyricsState.Loaded)?.song?.id
     val loadedSong = (state.lyricsState as? LyricsState.Loaded)?.song
     val lyricsAlignment =
@@ -251,6 +262,8 @@ fun LyricsPage(
                                             modifier =
                                                 Modifier
                                                     .fillMaxWidth()
+                                                    .statusBarsPadding()
+                                                    .displayCutoutPadding()
                                                     .padding(horizontal = 16.dp),
                                             horizontalAlignment = lyricsAlignment,
                                         ) {
@@ -275,9 +288,8 @@ fun LyricsPage(
                                             Text(
                                                 text = lyricsState.song.title,
                                                 style =
-                                                    MaterialTheme.typography.headlineMedium.copy(
-                                                        fontFamily = flexFontEmphasis()
-                                                    ),
+                                                    MaterialTheme.typography.headlineMedium,
+                                                fontFamily = flexFontEmphasis(),
                                                 maxLines = 1,
                                                 overflow = TextOverflow.Ellipsis,
                                                 modifier =
@@ -289,9 +301,8 @@ fun LyricsPage(
                                             Text(
                                                 text = lyricsState.song.artists,
                                                 style =
-                                                    MaterialTheme.typography.titleMedium.copy(
-                                                        fontFamily = flexFontRounded()
-                                                    ),
+                                                    MaterialTheme.typography.titleMedium,
+                                                fontFamily = flexFontRounded(),
                                                 fontWeight = FontWeight.Bold,
                                                 maxLines = 1,
                                                 overflow = TextOverflow.Ellipsis,
@@ -357,6 +368,7 @@ fun LyricsPage(
                                         modifier =
                                             Modifier
                                                 .fillMaxSize()
+                                                .safeDrawingPadding()
                                                 .padding(horizontal = 16.dp),
                                         verticalAlignment = Alignment.CenterVertically,
                                         horizontalArrangement = Arrangement.spacedBy(24.dp),
@@ -465,6 +477,7 @@ fun LyricsPage(
         Column(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
+                .navigationBarsPadding()
                 .padding(bottom = 32.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -529,9 +542,8 @@ fun LyricsPage(
                                         Text(
                                             text = stringResource(R.string.not_found),
                                             style =
-                                                MaterialTheme.typography.bodySmall.copy(
-                                                    fontWeight = FontWeight.Bold
-                                                ),
+                                                MaterialTheme.typography.bodySmall,
+                                            fontWeight = FontWeight.Bold,
                                             maxLines = 1,
                                             overflow = TextOverflow.Ellipsis,
                                         )
@@ -567,7 +579,7 @@ fun LyricsPage(
                             ),
                         shapes =
                             IconButtonShapes(
-                                shape = RoundedCornerShape(1000.dp),
+                                shape = CircleShape,
                                 pressedShape = RoundedCornerShape(16.dp),
                             ),
                     ) {
@@ -585,22 +597,20 @@ fun LyricsPage(
                             ),
                         shapes =
                             IconButtonShapes(
-                                shape = RoundedCornerShape(1000.dp),
+                                shape = CircleShape,
                                 pressedShape = RoundedCornerShape(16.dp),
                             ),
                         onClick = { action(LyricsPageAction.OnPauseOrResume) },
                         modifier =
                             Modifier
-                                .run {
-                                    if (state.lyricsBackground in audioDependentBackgrounds) {
-                                        glowBackground(
-                                            (24 * glowMultiplier).dp,
-                                            CircleShape,
-                                            cardContent,
-                                        )
-                                    } else {
-                                        this
-                                    }
+                                .conditional(
+                                    state.lyricsBackground in audioDependentBackgrounds
+                                ) {
+                                    glowBackground(
+                                        glowCardBackground.dp,
+                                        CircleShape,
+                                        cardContent,
+                                    )
                                 }
                                 .height(60.dp)
                                 .width(120.dp),
@@ -622,7 +632,7 @@ fun LyricsPage(
                         onClick = { action(LyricsPageAction.OnPlayNext) },
                         shapes =
                             IconButtonShapes(
-                                shape = RoundedCornerShape(1000.dp),
+                                shape = CircleShape,
                                 pressedShape = RoundedCornerShape(16.dp),
                             ),
                         colors =

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsPage.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsPage.kt
@@ -18,6 +18,7 @@ package com.shub39.rush.presentation.lyrics.section
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.togetherWith
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.fadeIn
@@ -64,6 +65,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.keepScreenOn
 import androidx.compose.ui.layout.ContentScale
@@ -482,77 +484,90 @@ fun LyricsPage(
             verticalArrangement = Arrangement.spacedBy(8.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            AnimatedVisibility(
-                visible = state.autoChange,
-                modifier = Modifier.widthIn(max = 150.dp),
-                enter = fadeIn(MaterialTheme.motionScheme.fastSpatialSpec()),
-                exit = fadeOut(MaterialTheme.motionScheme.fastSpatialSpec()),
-            ) {
-                AnimatedContent(targetState = state.searchState) {
-                    when (it) {
-                        SearchState.Idle -> {}
-                        is SearchState.Searching -> {
-                            Card(
-                                shape = RoundedCornerShape(100.dp),
-                                colors =
-                                    CardDefaults.cardColors(
-                                        contentColor = cardBackground,
-                                        containerColor = cardContent,
-                                    ),
-                            ) {
-                                Row(
-                                    modifier = Modifier.padding(16.dp),
-                                    verticalAlignment = Alignment.CenterVertically,
+            val autoChangeAlpha by animateFloatAsState(
+                targetValue = if (state.autoChange) 1f else 0f,
+                animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+                label = "autoChangeAlpha"
+            )
+
+            if (autoChangeAlpha > 0f) {
+                Box(
+                    modifier = Modifier
+                        .widthIn(max = 150.dp)
+                        .graphicsLayer { alpha = autoChangeAlpha }
+                ) {
+                    AnimatedContent(
+                        targetState = state.searchState,
+                        transitionSpec = {
+                            fadeIn() togetherWith fadeOut()
+                        },
+                        label = "searchState"
+                    ) { searchState ->
+                        when (searchState) {
+                            SearchState.Idle -> {}
+                            is SearchState.Searching -> {
+                                Card(
+                                    shape = RoundedCornerShape(100.dp),
+                                    colors =
+                                        CardDefaults.cardColors(
+                                            contentColor = cardBackground,
+                                            containerColor = cardContent,
+                                        ),
                                 ) {
-                                    LoadingIndicator(
-                                        color = cardBackground,
-                                        modifier = Modifier.size(20.dp),
-                                    )
-                                    Spacer(modifier = Modifier.width(6.dp))
-                                    Text(
-                                        text = it.query,
-                                        style = MaterialTheme.typography.bodySmall,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis,
-                                    )
+                                    Row(
+                                        modifier = Modifier.padding(16.dp),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        LoadingIndicator(
+                                            color = cardBackground,
+                                            modifier = Modifier.size(20.dp),
+                                        )
+                                        Spacer(modifier = Modifier.width(6.dp))
+                                        Text(
+                                            text = searchState.query,
+                                            style = MaterialTheme.typography.bodySmall,
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis,
+                                        )
+                                    }
                                 }
                             }
-                        }
 
-                        SearchState.UserPrompt -> {
-                            Card(
-                                shape = RoundedCornerShape(100.dp),
-                                colors =
-                                    CardDefaults.cardColors(
-                                        contentColor = cardBackground,
-                                        containerColor = cardContent,
-                                    ),
-                                onClick = { action(LyricsPageAction.OnToggleSearchSheet) },
-                            ) {
-                                Row(
-                                    modifier = Modifier.padding(16.dp),
-                                    verticalAlignment = Alignment.CenterVertically,
+                            SearchState.UserPrompt -> {
+                                Card(
+                                    shape = RoundedCornerShape(100.dp),
+                                    colors =
+                                        CardDefaults.cardColors(
+                                            contentColor = cardBackground,
+                                            containerColor = cardContent,
+                                        ),
+                                    onClick = { action(LyricsPageAction.OnToggleSearchSheet) },
                                 ) {
-                                    Icon(
-                                        painter = painterResource(R.drawable.search_off),
-                                        contentDescription = "No exact match found",
-                                    )
-                                    Spacer(modifier = Modifier.width(6.dp))
-                                    Column {
-                                        Text(
-                                            text = stringResource(R.string.not_found),
-                                            style =
-                                                MaterialTheme.typography.bodySmall,
-                                            fontWeight = FontWeight.Bold,
-                                            maxLines = 1,
-                                            overflow = TextOverflow.Ellipsis,
+                                    Row(
+                                        modifier = Modifier.padding(16.dp),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        Icon(
+                                            painter = painterResource(R.drawable.search_off),
+                                            contentDescription = "No exact match found",
                                         )
-                                        Text(
-                                            text = stringResource(R.string.open_search),
-                                            style = MaterialTheme.typography.labelSmall,
-                                            maxLines = 1,
-                                            overflow = TextOverflow.Ellipsis,
-                                        )
+                                        Spacer(modifier = Modifier.width(6.dp))
+                                        Column {
+                                            Text(
+                                                text = stringResource(R.string.not_found),
+                                                style =
+                                                    MaterialTheme.typography.bodySmall,
+                                                fontWeight = FontWeight.Bold,
+                                                maxLines = 1,
+                                                overflow = TextOverflow.Ellipsis,
+                                            )
+                                            Text(
+                                                text = stringResource(R.string.open_search),
+                                                style = MaterialTheme.typography.labelSmall,
+                                                maxLines = 1,
+                                                overflow = TextOverflow.Ellipsis,
+                                            )
+                                        }
                                     }
                                 }
                             }

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsPage.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsPage.kt
@@ -116,8 +116,8 @@ import com.shub39.rush.presentation.theme.flexFontEmphasis
 import com.shub39.rush.presentation.theme.flexFontRounded
 import com.shub39.rush.presentation.toAlignment
 import io.gitlab.bpavuk.viz.VisualizerData
-import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
 
 @Composable
 fun LyricsPage(
@@ -353,9 +353,7 @@ fun LyricsPage(
                                         verticalAlignment = Alignment.CenterVertically,
                                         horizontalArrangement = Arrangement.spacedBy(16.dp),
                                     ) {
-                                        Column(
-                                            modifier = Modifier.animateContentSize()
-                                        ) {
+                                        Column(modifier = Modifier.animateContentSize()) {
                                             Actions(
                                                 state = actionsState,
                                                 action = action,

--- a/app/src/main/java/com/shub39/rush/warning/WarningDialog.kt
+++ b/app/src/main/java/com/shub39/rush/warning/WarningDialog.kt
@@ -54,10 +54,8 @@ fun WarningDialog(onDismissRequest: () -> Unit, modifier: Modifier = Modifier) {
     BasicAlertDialog(modifier = modifier, onDismissRequest = onDismissRequest) {
         Card(shape = MaterialTheme.shapes.extraLarge) {
             Column(
-                modifier = Modifier
-                    .padding(16.dp)
-                    .fillMaxWidth()
-                    .verticalScroll(rememberScrollState()),
+                modifier =
+                    Modifier.padding(16.dp).fillMaxWidth().verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 Box(
@@ -78,16 +76,16 @@ fun WarningDialog(onDismissRequest: () -> Unit, modifier: Modifier = Modifier) {
 
                 Text(
                     text = "Important Warning",
-                    style =  MaterialTheme.typography.headlineSmall.copy(
-                        fontFamily = flexFontEmphasis(),
-                        color = MaterialTheme.colorScheme.error,
-                    ),
+                    style =
+                        MaterialTheme.typography.headlineSmall.copy(
+                            fontFamily = flexFontEmphasis(),
+                            color = MaterialTheme.colorScheme.error,
+                        ),
                 )
                 Text(
                     text = "Your phone is about to stop being yours.",
-                    style = MaterialTheme.typography.titleMedium.copy(
-                        fontFamily = flexFontRounded()
-                    ),
+                    style =
+                        MaterialTheme.typography.titleMedium.copy(fontFamily = flexFontRounded()),
                 )
 
                 Row(
@@ -96,10 +94,11 @@ fun WarningDialog(onDismissRequest: () -> Unit, modifier: Modifier = Modifier) {
                 ) {
                     Text(
                         text = WarningManager.getDaysLeft().toString(),
-                        style = MaterialTheme.typography.displayLarge.copy(
-                            fontFamily = flexFontEmphasis(),
-                            color = MaterialTheme.colorScheme.error,
-                        ),
+                        style =
+                            MaterialTheme.typography.displayLarge.copy(
+                                fontFamily = flexFontEmphasis(),
+                                color = MaterialTheme.colorScheme.error,
+                            ),
                     )
                     Text(text = "DAYS UNTIL LOCKDOWN", style = MaterialTheme.typography.titleMedium)
                 }
@@ -115,10 +114,11 @@ fun WarningDialog(onDismissRequest: () -> Unit, modifier: Modifier = Modifier) {
 
                 Text(
                     text = "Every app and every device, worldwide, with no opt-out.",
-                    style = MaterialTheme.typography.bodyMedium.copy(
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.error,
-                    ),
+                    style =
+                        MaterialTheme.typography.bodyMedium.copy(
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.error,
+                        ),
                 )
 
                 Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {

--- a/app/src/main/java/com/shub39/rush/warning/WarningDialog.kt
+++ b/app/src/main/java/com/shub39/rush/warning/WarningDialog.kt
@@ -73,16 +73,14 @@ fun WarningDialog(onDismissRequest: () -> Unit, modifier: Modifier = Modifier) {
 
                 Text(
                     text = "Important Warning",
-                    style =
-                        MaterialTheme.typography.headlineSmall,
+                    style = MaterialTheme.typography.headlineSmall,
                     color = MaterialTheme.colorScheme.error,
-                    fontFamily = flexFontEmphasis()
+                    fontFamily = flexFontEmphasis(),
                 )
                 Text(
                     text = "Your phone is about to stop being yours.",
-                    style =
-                        MaterialTheme.typography.titleMedium,
-                    fontFamily = flexFontRounded()
+                    style = MaterialTheme.typography.titleMedium,
+                    fontFamily = flexFontRounded(),
                 )
 
                 Row(
@@ -91,8 +89,7 @@ fun WarningDialog(onDismissRequest: () -> Unit, modifier: Modifier = Modifier) {
                 ) {
                     Text(
                         text = WarningManager.getDaysLeft().toString(),
-                        style =
-                            MaterialTheme.typography.displayLarge,
+                        style = MaterialTheme.typography.displayLarge,
                         fontFamily = flexFontEmphasis(),
                         color = MaterialTheme.colorScheme.error,
                     )
@@ -110,8 +107,7 @@ fun WarningDialog(onDismissRequest: () -> Unit, modifier: Modifier = Modifier) {
 
                 Text(
                     text = "Every app and every device, worldwide, with no opt-out.",
-                    style =
-                        MaterialTheme.typography.bodyMedium,
+                    style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.error,
                 )

--- a/app/src/main/java/com/shub39/rush/warning/WarningDialog.kt
+++ b/app/src/main/java/com/shub39/rush/warning/WarningDialog.kt
@@ -74,15 +74,15 @@ fun WarningDialog(onDismissRequest: () -> Unit, modifier: Modifier = Modifier) {
                 Text(
                     text = "Important Warning",
                     style =
-                        MaterialTheme.typography.headlineSmall.copy(
-                            fontFamily = flexFontEmphasis(),
-                            color = MaterialTheme.colorScheme.error,
-                        ),
+                        MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.error,
+                    fontFamily = flexFontEmphasis()
                 )
                 Text(
                     text = "Your phone is about to stop being yours.",
                     style =
-                        MaterialTheme.typography.titleMedium.copy(fontFamily = flexFontRounded()),
+                        MaterialTheme.typography.titleMedium,
+                    fontFamily = flexFontRounded()
                 )
 
                 Row(
@@ -92,10 +92,9 @@ fun WarningDialog(onDismissRequest: () -> Unit, modifier: Modifier = Modifier) {
                     Text(
                         text = WarningManager.getDaysLeft().toString(),
                         style =
-                            MaterialTheme.typography.displayLarge.copy(
-                                fontFamily = flexFontEmphasis(),
-                                color = MaterialTheme.colorScheme.error,
-                            ),
+                            MaterialTheme.typography.displayLarge,
+                        fontFamily = flexFontEmphasis(),
+                        color = MaterialTheme.colorScheme.error,
                     )
                     Text(text = "DAYS UNTIL LOCKDOWN", style = MaterialTheme.typography.titleMedium)
                 }
@@ -112,10 +111,9 @@ fun WarningDialog(onDismissRequest: () -> Unit, modifier: Modifier = Modifier) {
                 Text(
                     text = "Every app and every device, worldwide, with no opt-out.",
                     style =
-                        MaterialTheme.typography.bodyMedium.copy(
-                            fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.error,
-                        ),
+                        MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.error,
                 )
 
                 Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {

--- a/app/src/main/java/com/shub39/rush/warning/WarningDialog.kt
+++ b/app/src/main/java/com/shub39/rush/warning/WarningDialog.kt
@@ -24,6 +24,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -52,7 +54,10 @@ fun WarningDialog(onDismissRequest: () -> Unit, modifier: Modifier = Modifier) {
     BasicAlertDialog(modifier = modifier, onDismissRequest = onDismissRequest) {
         Card(shape = MaterialTheme.shapes.extraLarge) {
             Column(
-                modifier = Modifier.padding(16.dp).fillMaxWidth(),
+                modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState()),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 Box(
@@ -73,14 +78,16 @@ fun WarningDialog(onDismissRequest: () -> Unit, modifier: Modifier = Modifier) {
 
                 Text(
                     text = "Important Warning",
-                    style = MaterialTheme.typography.headlineSmall,
-                    color = MaterialTheme.colorScheme.error,
-                    fontFamily = flexFontEmphasis(),
+                    style =  MaterialTheme.typography.headlineSmall.copy(
+                        fontFamily = flexFontEmphasis(),
+                        color = MaterialTheme.colorScheme.error,
+                    ),
                 )
                 Text(
                     text = "Your phone is about to stop being yours.",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontFamily = flexFontRounded(),
+                    style = MaterialTheme.typography.titleMedium.copy(
+                        fontFamily = flexFontRounded()
+                    ),
                 )
 
                 Row(
@@ -89,9 +96,10 @@ fun WarningDialog(onDismissRequest: () -> Unit, modifier: Modifier = Modifier) {
                 ) {
                     Text(
                         text = WarningManager.getDaysLeft().toString(),
-                        style = MaterialTheme.typography.displayLarge,
-                        fontFamily = flexFontEmphasis(),
-                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.displayLarge.copy(
+                            fontFamily = flexFontEmphasis(),
+                            color = MaterialTheme.colorScheme.error,
+                        ),
                     )
                     Text(text = "DAYS UNTIL LOCKDOWN", style = MaterialTheme.typography.titleMedium)
                 }
@@ -107,9 +115,10 @@ fun WarningDialog(onDismissRequest: () -> Unit, modifier: Modifier = Modifier) {
 
                 Text(
                     text = "Every app and every device, worldwide, with no opt-out.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.error,
+                    ),
                 )
 
                 Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the lyrics presentation components, focusing on system bar handling and state management. The most significant changes include refactoring system bar utilities for better integration with Compose, extracting and generalizing the synced lyrics scrolling logic into a reusable component, and improving state immutability for data classes used in Compose. Additionally, new utility functions and performance optimizations have been added.

A lot of changes related to calculations has been made, following the best Jetpack Compose state-related solutions. In summary, overall lag has been reduced (and it's notorious).

**System Bar Handling and Utilities:**
- Refactored system bar update utilities to accept a `View` instead of `Context`, improving integration with Compose and enabling more precise control over fullscreen and system bar behavior. Added a new `resetSystemBars` function for restoring default state.
- Repalced the old `KeepScreenOn` composable and related unused imports with the brand new Google-made modifier.

**Lyrics Scrolling and Presentation:**
- Extracted and generalized the synced lyrics scrolling and auto-centering logic into a new composable, `BaseSyncedLyrics`, allowing for code reuse and easier customization of lyrics presentation.
- Added a `conditional` extension function to `Modifier` to simplify conditional modifier application in Compose layouts.
- Added a `rememberLineProgress` composable utility for efficient calculation and memoization of lyric line progress, improving performance and code clarity.

**State Management and Immutability:**
- Marked `ParsedLine` and `ParsedWord` data classes as `@Stable` and `@Immutable` respectively, ensuring Compose can optimize recompositions and improving code safety.
- Introduced a new immutable `ActionsState` data class to encapsulate the state for the lyrics actions component, replacing direct usage of `LyricsPageState` and improving separation of concerns.

**Codebase Simplification:**
- Cleaned up and removed unused imports from several files, especially in lyrics components, to reduce clutter and improve maintainability.
- Updated usages of lyrics state and song data in the actions component to use the new `ActionsState`, improving clarity and reducing coupling.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refactors the lyrics page for improved performance and layout correctness: scroll/blur logic is extracted into a reusable `BaseSyncedLyrics` composable, system-bar control moves from `Context` to `View`, and several Compose stability annotations and state-management improvements are applied throughout.

- **`BaseSyncedLyrics`** centralises auto-centering, drag-pause, and per-item blur animation for both `LineSyncedLyrics` and `SyllableSyncedLyrics`, eliminating duplicated `LaunchedEffect`/`mutableStateMapOf` blocks.
- **System-bar handling** is fixed in `LyricsGraph`: `DisposableEffect` now keys on `lyricsState.fullscreen` so toggling fullscreen mid-session actually updates the bars (the old single-run `Unit`-keyed effect was a silent bug).
- **`ActionsState`** decouples the `Actions` composable from the full `LyricsPageState`; `@Immutable` should be re-added after both stability annotations were removed in response to prior review feedback.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the changes are well-scoped UI refactors with no regressions in core playback or data logic.

The core correctness work (system-bar fullscreen fix, de-duplicated scroll logic, romanization map hoisted out of item loops) is solid. The two findings are both minor style/inset concerns with limited blast radius: one affects an obscure device configuration in a secondary screen, the other is a missing annotation that has no functional impact given the remember(keys) guard already in place.

LyricsCustomisationPage.kt (lateral inset regression) and Actions.kt (missing @Immutable on ActionsState)
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/src/main/java/com/shub39/rush/presentation/lyrics/component/BaseSyncedLyrics.kt | New generic composable that extracts and centralises synced-lyric scroll and blur logic from both LineSyncedLyrics and SyllableSyncedLyrics; scroll-pause timeout, user-drag detection, and per-item height tracking look correct. |
| app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsPage.kt | Replaced KeepScreenOn composable with Modifier.keepScreenOn(), moved windowSizeClass out of the loaded-state branch, and improved LaunchedEffect key from lyricsState to songId; glowCardBackground uses remember(glowMultiplier){ mutableFloatStateOf(…) } which allocates a new MutableFloatState on every animation frame. |
| app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsCustomisationPage.kt | Lateral window-inset padding removed from LazyColumn contentPadding; could clip content on devices with side navigation bars. |
| app/src/main/java/com/shub39/rush/presentation/Util.kt | updateSystemBars refactored to take View instead of Context, resetSystemBars added, KeepScreenOn composable removed, and conditional Modifier extension added — all clean with no issues found. |
| app/src/main/java/com/shub39/rush/presentation/lyrics/LyricsGraph.kt | DisposableEffect now keys on lyricsState.fullscreen (fixing the old bug where toggling fullscreen mid-session never updated system bars), and uses resetSystemBars on dispose. |
| app/src/main/java/com/shub39/rush/presentation/lyrics/component/Actions.kt | Introduced ActionsState to decouple Actions from LyricsPageState; both @Immutable and @Stable were removed in response to a prior review comment but @Immutable alone should have been kept. |
| app/src/main/java/com/shub39/rush/presentation/lyrics/Util.kt | rememberLineProgress composable added; unit handling (Long ms → Double seconds) is consistent across both LineSyncedLyrics and SyllableSyncedLyrics call sites. |
| app/src/main/java/com/shub39/rush/presentation/lyrics/component/LineSyncedLyrics.kt | Delegated scroll/blur logic to BaseSyncedLyrics and moved romanization map computation outside the items loop; unit handling in rememberLineProgress call is correct. |
| app/src/main/java/com/shub39/rush/presentation/lyrics/component/PlainLyrics.kt | Auto-scrape LaunchedEffect moved outside the LazyColumn, nonEmptyItems computed with remember, and lazy items given stable keys/contentTypes — all clean. |
| app/src/main/java/com/shub39/rush/warning/WarningDialog.kt | verticalScroll added to the dialog Column for long-content safety; no issues. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant LP as LyricsPage
    participant BL as BaseSyncedLyrics
    participant LL as LineSyncedLyrics
    participant SL as SyllableSyncedLyrics
    participant LG as LyricsGraph

    LP->>LG: lyricsState.fullscreen changes
    LG->>LG: DisposableEffect(view, fullscreen) relaunches
    LG->>LG: updateSystemBars(view, fullscreen)

    LP->>LL: state, playbackInfo
    LL->>LL: remember(position, syncedLyrics) → currentPlayingIndex
    LL->>BL: items, currentPlayingIndex, itemContent lambda

    LP->>SL: state, playbackInfo
    SL->>SL: remember(position, ttmlLyrics) → currentPlayingIndex
    SL->>BL: items, currentPlayingIndex, itemContent lambda

    BL->>BL: LaunchedEffect(currentPlayingIndex, …) → animateScrollToItem
    BL->>BL: LaunchedEffect(isUserScrolling) → pauseAutoScroll with 3s delay
    BL-->>LL: itemContent(index, lyric, blur)
    BL-->>SL: itemContent(index, line, blur)
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsPage.kt`, line 1334 ([link](https://github.com/shub39/rush/blob/aa3d094c8b18de936bb815b79130dad404158e44/app/src/main/java/com/shub39/rush/presentation/lyrics/section/LyricsPage.kt#L1334)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Glow animation frozen at initial value**

   `remember { mutableFloatStateOf(24 * glowMultiplier) }` has no keys, so the `MutableFloatState` is only initialised once — at the moment the composable first enters the composition, when `glowMultiplier` is likely still 0 (or whatever the initial animation start value is). On all subsequent recompositions, `remember` returns the same `MutableFloatState` object (no keys to invalidate it), so `glowCardBackground` never reflects the animating `glowMultiplier`. The play-button glow radius will always be stuck at the initial value, making the audio-reactive glow permanently broken.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: [":wrench: chore: applied spotless"](https://github.com/shub39/rush/commit/9d3e3a6dfefb6c77c8ed9eb12a7159effc181d3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32356124)</sub>

<!-- /greptile_comment -->