### PR TITLE
6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.2.0
+- Fixed Expressive Syllables causing crashes
+- Fixed UI inconsistencies
+
 ## 6.1.15
 - (Android 12+) Fixed Material Theme not respecting System Colors
 - Updated Translations

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,8 +26,8 @@ plugins {
 }
 
 val appName = "Rush"
-val appVersionName = "6.1.15"
-val appVersionCode = 6115
+val appVersionName = "6.2.0"
+val appVersionCode = 6200
 
 val publicGeniusApiToken = "\"qLSDtgIqHgzGNjOFUmdOxJKGJOg5RIAPzOKTfrs7rNxqYXwfdSh9HTHMJUs2X27Y\""
 

--- a/app/src/main/assets/changelog.json
+++ b/app/src/main/assets/changelog.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "6.2.0",
+    "changes": [
+      "Fixed Expressive Syllables causing crashes",
+      "Fixed UI inconsistencies"
+    ]
+  },
+  {
     "version": "6.1.15",
     "changes": [
       "(Android 12+) Fixed Material Theme not respecting System Colors",
@@ -70,13 +77,6 @@
     "version": "5.8.1",
     "changes": [
       "Miscellaneous updates and fixes"
-    ]
-  },
-  {
-    "version": "5.8.0",
-    "changes": [
-      "Added Expressive motion scheme to animations",
-      "Updated Translations"
     ]
   }
 ]

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/SyllableSyncedLyrics.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/SyllableSyncedLyrics.kt
@@ -118,36 +118,36 @@ fun SyllableSyncedLyrics(
             )
 
         val animatedProgress by
-        animateFloatAsState(
-            targetValue = progress,
-            animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-            label = "loadingProgress",
-        )
+            animateFloatAsState(
+                targetValue = progress,
+                animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+                label = "loadingProgress",
+            )
 
         val underTextAlpha by
-        animateFloatAsState(
-            targetValue = if (isCurrent) 0.5f else 0.2f,
-            animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-            label = "underTextAlpha",
-        )
+            animateFloatAsState(
+                targetValue = if (isCurrent) 0.5f else 0.2f,
+                animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+                label = "underTextAlpha",
+            )
 
         val scale by
-        animateFloatAsState(
-            targetValue = if (isCurrent) 1f else 0.8f,
-            animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
-            label = "scale",
-        )
+            animateFloatAsState(
+                targetValue = if (isCurrent) 1f else 0.8f,
+                animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+                label = "scale",
+            )
 
         val textColor by
-        animateColorAsState(
-            targetValue =
-                when {
-                    (line.startTime * 1000).toLong() <= currentTime -> cardContent
-                    else -> cardContent.copy(0.3f)
-                },
-            animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-            label = "textColor",
-        )
+            animateColorAsState(
+                targetValue =
+                    when {
+                        (line.startTime * 1000).toLong() <= currentTime -> cardContent
+                        else -> cardContent.copy(0.3f)
+                    },
+                animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+                label = "textColor",
+            )
 
         SyllableLine(
             textPrefs = state.textPrefs,
@@ -190,8 +190,7 @@ fun SyllableLine(
     ) {
         Box(
             modifier =
-                Modifier
-                    .graphicsLayer {
+                Modifier.graphicsLayer {
                         scaleX = scale
                         scaleY = scale
                         transformOrigin = textPrefs.lyricsAlignment.toTransformOrigin()
@@ -304,26 +303,26 @@ private fun SyllableWord(
         }
 
     val animatedProgress by
-    animateFloatAsState(
-        targetValue = wordProgress,
-        animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
-        label = "wordProgress",
-    )
+        animateFloatAsState(
+            targetValue = wordProgress,
+            animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+            label = "wordProgress",
+        )
 
     // word highlighting design
     val isHighlighted = currentTime >= wordStartTimeMs
     val wordScale by
-    animateFloatAsState(
-        targetValue = if (isHighlighted || scale != 1f) 1f else 0.95f,
-        animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
-        label = "wordScale",
-    )
+        animateFloatAsState(
+            targetValue = if (isHighlighted || scale != 1f) 1f else 0.95f,
+            animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+            label = "wordScale",
+        )
     val glowAlpha by
-    animateFloatAsState(
-        targetValue = if (isHighlighted) 2f else 0f,
-        animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-        label = "glowAlpha",
-    )
+        animateFloatAsState(
+            targetValue = if (isHighlighted) 2f else 0f,
+            animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+            label = "glowAlpha",
+        )
 
     val baseTextStyle =
         MaterialTheme.typography.bodyLarge.copy(
@@ -332,90 +331,91 @@ private fun SyllableWord(
             lineHeight = textPrefs.lineHeight.sp,
             textAlign = textPrefs.lyricsAlignment.toTextAlignment(),
         )
-    val textStyle1 = remember(maxWordWeight, maxWordWidth, textPrefs, expressiveSyllables) {
-        if (expressiveSyllables) {
-            baseTextStyle.copy(fontFamily = flexFontEmphasis(fontWeight = 300, fontWidth = 100f))
-        } else baseTextStyle
-    }
-    val textStyle2 = remember(maxWordWeight, maxWordWidth, textPrefs, expressiveSyllables) {
-        if (expressiveSyllables) {
-            textStyle1.copy(
-                fontFamily = flexFontEmphasis(fontWeight = maxWordWeight, fontWidth = maxWordWidth)
-            )
-        } else textStyle1
-    }
+    val textStyle1 =
+        remember(maxWordWeight, maxWordWidth, textPrefs, expressiveSyllables) {
+            if (expressiveSyllables) {
+                baseTextStyle.copy(
+                    fontFamily = flexFontEmphasis(fontWeight = 300, fontWidth = 100f)
+                )
+            } else baseTextStyle
+        }
+    val textStyle2 =
+        remember(maxWordWeight, maxWordWidth, textPrefs, expressiveSyllables) {
+            if (expressiveSyllables) {
+                textStyle1.copy(
+                    fontFamily =
+                        flexFontEmphasis(fontWeight = maxWordWeight, fontWidth = maxWordWidth)
+                )
+            } else textStyle1
+        }
 
     Box(
         modifier =
-            Modifier
-                .padding(horizontal = 4.dp)
-                .graphicsLayer {
-                    scaleX = wordScale
-                    scaleY = wordScale
-                }
+            Modifier.padding(horizontal = 4.dp).graphicsLayer {
+                scaleX = wordScale
+                scaleY = wordScale
+            }
     ) {
         // skeleton
         Text(text = word.text, style = textStyle2, modifier = Modifier.alpha(0f))
 
         Box(
-            modifier = Modifier
-                .matchParentSize()
-                .blur(radius = glowAlpha.dp, edgeTreatment = BlurredEdgeTreatment.Unbounded)
-
-        ) {
-            Text(
-                text = word.text,
-                style = textStyle1,
-                color = textColor.copy(alpha = underTextAlpha),
-                modifier = Modifier.alpha(1 - animatedProgress)
-            )
-
-            Text(
-                text = word.text,
-                style = textStyle2,
-                color = textColor.copy(alpha = underTextAlpha),
-                modifier = Modifier.alpha(animatedProgress)
-            )
-        }
-
-        Box(
-            modifier = Modifier
-                .matchParentSize()
-                .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
-                .drawWithContent {
-                    if (animatedProgress > 0f) {
+            modifier =
+                Modifier.matchParentSize()
+                    .blur(radius = glowAlpha.dp, edgeTreatment = BlurredEdgeTreatment.Unbounded)
+                    .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
+                    .drawWithContent {
                         drawContent()
-                        if (animatedProgress < 1f) {
+                        if (animatedProgress > 0f) {
                             val feather = 16.dp.toPx()
                             val x = (size.width + feather) * animatedProgress
                             drawRect(
                                 brush =
                                     Brush.horizontalGradient(
-                                        0f to Color.Black,
+                                        0f to Color.Transparent,
                                         ((x - feather) / size.width).coerceIn(0f, 1f) to
-                                                Color.Black,
-                                        (x / size.width).coerceIn(0f, 1f) to Color.Transparent,
-                                        1f to Color.Transparent,
+                                            Color.Transparent,
+                                        (x / size.width).coerceIn(0f, 1f) to Color.Black,
+                                        1f to Color.Black,
                                     ),
                                 blendMode = BlendMode.DstIn,
                             )
                         }
                     }
-                }
         ) {
             Text(
                 text = word.text,
                 style = textStyle1,
-                color = textColor,
-                modifier = Modifier.alpha(1 - animatedProgress)
+                color = textColor.copy(alpha = underTextAlpha),
             )
+        }
 
-            Text(
-                text = word.text,
-                style = textStyle2,
-                color = textColor,
-                modifier = Modifier.alpha(animatedProgress)
-            )
+        Box(
+            modifier =
+                Modifier.matchParentSize()
+                    .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
+                    .drawWithContent {
+                        if (animatedProgress > 0f) {
+                            drawContent()
+                            if (animatedProgress < 1f) {
+                                val feather = 16.dp.toPx()
+                                val x = (size.width + feather) * animatedProgress
+                                drawRect(
+                                    brush =
+                                        Brush.horizontalGradient(
+                                            0f to Color.Black,
+                                            ((x - feather) / size.width).coerceIn(0f, 1f) to
+                                                Color.Black,
+                                            (x / size.width).coerceIn(0f, 1f) to Color.Transparent,
+                                            1f to Color.Transparent,
+                                        ),
+                                    blendMode = BlendMode.DstIn,
+                                )
+                            }
+                        }
+                    }
+        ) {
+            Text(text = word.text, style = textStyle2, color = textColor)
         }
     }
 }

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/SyllableSyncedLyrics.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/SyllableSyncedLyrics.kt
@@ -51,7 +51,6 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.lerp
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.Dp
@@ -119,36 +118,36 @@ fun SyllableSyncedLyrics(
             )
 
         val animatedProgress by
-            animateFloatAsState(
-                targetValue = progress,
-                animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-                label = "loadingProgress",
-            )
+        animateFloatAsState(
+            targetValue = progress,
+            animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+            label = "loadingProgress",
+        )
 
         val underTextAlpha by
-            animateFloatAsState(
-                targetValue = if (isCurrent) 0.5f else 0.2f,
-                animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-                label = "underTextAlpha",
-            )
+        animateFloatAsState(
+            targetValue = if (isCurrent) 0.5f else 0.2f,
+            animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+            label = "underTextAlpha",
+        )
 
         val scale by
-            animateFloatAsState(
-                targetValue = if (isCurrent) 1f else 0.8f,
-                animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
-                label = "scale",
-            )
+        animateFloatAsState(
+            targetValue = if (isCurrent) 1f else 0.8f,
+            animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+            label = "scale",
+        )
 
         val textColor by
-            animateColorAsState(
-                targetValue =
-                    when {
-                        (line.startTime * 1000).toLong() <= currentTime -> cardContent
-                        else -> cardContent.copy(0.3f)
-                    },
-                animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-                label = "textColor",
-            )
+        animateColorAsState(
+            targetValue =
+                when {
+                    (line.startTime * 1000).toLong() <= currentTime -> cardContent
+                    else -> cardContent.copy(0.3f)
+                },
+            animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+            label = "textColor",
+        )
 
         SyllableLine(
             textPrefs = state.textPrefs,
@@ -191,7 +190,8 @@ fun SyllableLine(
     ) {
         Box(
             modifier =
-                Modifier.graphicsLayer {
+                Modifier
+                    .graphicsLayer {
                         scaleX = scale
                         scaleY = scale
                         transformOrigin = textPrefs.lyricsAlignment.toTransformOrigin()
@@ -304,42 +304,26 @@ private fun SyllableWord(
         }
 
     val animatedProgress by
-        animateFloatAsState(
-            targetValue = wordProgress,
-            animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
-            label = "wordProgress",
-        )
-
-    //    val currentWeight =
-    //        remember(animatedProgress, maxWordWeight) {
-    //            (((200 + (animatedProgress * (maxWordWeight - 200))) / 10).toInt() * 10).coerceIn(
-    //                200,
-    //                maxWordWeight,
-    //            )
-    //        }
-    //
-    //    val currentWidth =
-    //        remember(animatedProgress, maxWordWidth) {
-    //            (((100f + (animatedProgress * (maxWordWidth - 100f))) * 2).toInt() / 2f).coerceIn(
-    //                100f,
-    //                maxWordWidth,
-    //            )
-    //        }
+    animateFloatAsState(
+        targetValue = wordProgress,
+        animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+        label = "wordProgress",
+    )
 
     // word highlighting design
     val isHighlighted = currentTime >= wordStartTimeMs
     val wordScale by
-        animateFloatAsState(
-            targetValue = if (isHighlighted || scale != 1f) 1f else 0.95f,
-            animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
-            label = "wordScale",
-        )
+    animateFloatAsState(
+        targetValue = if (isHighlighted || scale != 1f) 1f else 0.95f,
+        animationSpec = MaterialTheme.motionScheme.fastSpatialSpec(),
+        label = "wordScale",
+    )
     val glowAlpha by
-        animateFloatAsState(
-            targetValue = if (isHighlighted) 2f else 0f,
-            animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
-            label = "glowAlpha",
-        )
+    animateFloatAsState(
+        targetValue = if (isHighlighted) 2f else 0f,
+        animationSpec = MaterialTheme.motionScheme.fastEffectsSpec(),
+        label = "glowAlpha",
+    )
 
     val baseTextStyle =
         MaterialTheme.typography.bodyLarge.copy(
@@ -348,69 +332,91 @@ private fun SyllableWord(
             lineHeight = textPrefs.lineHeight.sp,
             textAlign = textPrefs.lyricsAlignment.toTextAlignment(),
         )
-    val textStyle1 =
+    val textStyle1 = remember(maxWordWeight, maxWordWidth, textPrefs, expressiveSyllables) {
         if (expressiveSyllables) {
-            baseTextStyle.copy(fontFamily = flexFontEmphasis(fontWeight = 200, fontWidth = 100f))
+            baseTextStyle.copy(fontFamily = flexFontEmphasis(fontWeight = 300, fontWidth = 100f))
         } else baseTextStyle
-    val textStyle2 =
+    }
+    val textStyle2 = remember(maxWordWeight, maxWordWidth, textPrefs, expressiveSyllables) {
         if (expressiveSyllables) {
             textStyle1.copy(
                 fontFamily = flexFontEmphasis(fontWeight = maxWordWeight, fontWidth = maxWordWidth)
             )
         } else textStyle1
-
-    val textStyleAnim by animateFloatAsState(targetValue = if (isHighlighted) 1f else 0f)
-    val animatedTextStyle = lerp(textStyle1, textStyle2, textStyleAnim)
+    }
 
     Box(
         modifier =
-            Modifier.padding(horizontal = 4.dp).graphicsLayer {
-                scaleX = wordScale
-                scaleY = wordScale
-            }
+            Modifier
+                .padding(horizontal = 4.dp)
+                .graphicsLayer {
+                    scaleX = wordScale
+                    scaleY = wordScale
+                }
     ) {
-        // Ghost text for layout consistency
+        // skeleton
         Text(text = word.text, style = textStyle2, modifier = Modifier.alpha(0f))
 
-        // Undertext + Glow
-        Text(
-            text = word.text,
-            style = animatedTextStyle,
-            color = textColor.copy(alpha = underTextAlpha),
-            modifier =
-                Modifier.matchParentSize()
-                    .blur(radius = glowAlpha.dp, edgeTreatment = BlurredEdgeTreatment.Unbounded),
-        )
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+                .blur(radius = glowAlpha.dp, edgeTreatment = BlurredEdgeTreatment.Unbounded)
 
-        // Main Highlight Layer with Mask
-        Text(
-            text = word.text,
-            style = animatedTextStyle,
-            color = textColor,
-            modifier =
-                Modifier.matchParentSize()
-                    .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
-                    .drawWithContent {
-                        if (animatedProgress > 0f) {
-                            drawContent()
-                            if (animatedProgress < 1f) {
-                                val feather = 16.dp.toPx()
-                                val x = (size.width + feather) * animatedProgress
-                                drawRect(
-                                    brush =
-                                        Brush.horizontalGradient(
-                                            0f to Color.Black,
-                                            ((x - feather) / size.width).coerceIn(0f, 1f) to
+        ) {
+            Text(
+                text = word.text,
+                style = textStyle1,
+                color = textColor.copy(alpha = underTextAlpha),
+                modifier = Modifier.alpha(1 - animatedProgress)
+            )
+
+            Text(
+                text = word.text,
+                style = textStyle2,
+                color = textColor.copy(alpha = underTextAlpha),
+                modifier = Modifier.alpha(animatedProgress)
+            )
+        }
+
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+                .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
+                .drawWithContent {
+                    if (animatedProgress > 0f) {
+                        drawContent()
+                        if (animatedProgress < 1f) {
+                            val feather = 16.dp.toPx()
+                            val x = (size.width + feather) * animatedProgress
+                            drawRect(
+                                brush =
+                                    Brush.horizontalGradient(
+                                        0f to Color.Black,
+                                        ((x - feather) / size.width).coerceIn(0f, 1f) to
                                                 Color.Black,
-                                            (x / size.width).coerceIn(0f, 1f) to Color.Transparent,
-                                            1f to Color.Transparent,
-                                        ),
-                                    blendMode = BlendMode.DstIn,
-                                )
-                            }
+                                        (x / size.width).coerceIn(0f, 1f) to Color.Transparent,
+                                        1f to Color.Transparent,
+                                    ),
+                                blendMode = BlendMode.DstIn,
+                            )
                         }
-                    },
-        )
+                    }
+                }
+        ) {
+            Text(
+                text = word.text,
+                style = textStyle1,
+                color = textColor,
+                modifier = Modifier.alpha(1 - animatedProgress)
+            )
+
+            Text(
+                text = word.text,
+                style = textStyle2,
+                color = textColor,
+                modifier = Modifier.alpha(animatedProgress)
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/SyllableSyncedLyrics.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/SyllableSyncedLyrics.kt
@@ -50,8 +50,8 @@ import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.lerp
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.Dp
@@ -269,8 +269,6 @@ private fun SyllableWord(
     underTextAlpha: Float,
     scale: Float,
 ) {
-    val fontFamily = MaterialTheme.typography.bodyLarge.fontFamily
-
     val wordStartTimeMs = remember(word) { (word.startTime * 1000).toLong() }
     val wordEndTimeMs = remember(word) { (word.endTime * 1000).toLong() }
     val duration = remember(word) { (wordEndTimeMs - wordStartTimeMs).coerceAtLeast(1) }
@@ -312,21 +310,21 @@ private fun SyllableWord(
             label = "wordProgress",
         )
 
-    val currentWeight =
-        remember(animatedProgress, maxWordWeight) {
-            (((200 + (animatedProgress * (maxWordWeight - 200))) / 10).toInt() * 10).coerceIn(
-                200,
-                maxWordWeight,
-            )
-        }
-
-    val currentWidth =
-        remember(animatedProgress, maxWordWidth) {
-            (((100f + (animatedProgress * (maxWordWidth - 100f))) * 2).toInt() / 2f).coerceIn(
-                100f,
-                maxWordWidth,
-            )
-        }
+    //    val currentWeight =
+    //        remember(animatedProgress, maxWordWeight) {
+    //            (((200 + (animatedProgress * (maxWordWeight - 200))) / 10).toInt() * 10).coerceIn(
+    //                200,
+    //                maxWordWeight,
+    //            )
+    //        }
+    //
+    //    val currentWidth =
+    //        remember(animatedProgress, maxWordWidth) {
+    //            (((100f + (animatedProgress * (maxWordWidth - 100f))) * 2).toInt() / 2f).coerceIn(
+    //                100f,
+    //                maxWordWidth,
+    //            )
+    //        }
 
     // word highlighting design
     val isHighlighted = currentTime >= wordStartTimeMs
@@ -343,22 +341,26 @@ private fun SyllableWord(
             label = "glowAlpha",
         )
 
-    val textStyle =
-        remember(currentWeight, currentWidth, textPrefs, expressiveSyllables) {
-            TextStyle(
-                fontSize = textPrefs.fontSize.sp,
-                letterSpacing = textPrefs.letterSpacing.sp,
-                lineHeight = textPrefs.lineHeight.sp,
-                textAlign = textPrefs.lyricsAlignment.toTextAlignment(),
-                fontWeight = FontWeight.Bold,
-                fontFamily =
-                    if (expressiveSyllables) {
-                        flexFontEmphasis(fontWeight = currentWeight, fontWidth = currentWidth)
-                    } else {
-                        fontFamily
-                    },
+    val baseTextStyle =
+        MaterialTheme.typography.bodyLarge.copy(
+            fontSize = textPrefs.fontSize.sp,
+            letterSpacing = textPrefs.letterSpacing.sp,
+            lineHeight = textPrefs.lineHeight.sp,
+            textAlign = textPrefs.lyricsAlignment.toTextAlignment(),
+        )
+    val textStyle1 =
+        if (expressiveSyllables) {
+            baseTextStyle.copy(fontFamily = flexFontEmphasis(fontWeight = 200, fontWidth = 100f))
+        } else baseTextStyle
+    val textStyle2 =
+        if (expressiveSyllables) {
+            textStyle1.copy(
+                fontFamily = flexFontEmphasis(fontWeight = maxWordWeight, fontWidth = maxWordWidth)
             )
-        }
+        } else textStyle1
+
+    val textStyleAnim by animateFloatAsState(targetValue = if (isHighlighted) 1f else 0f)
+    val animatedTextStyle = lerp(textStyle1, textStyle2, textStyleAnim)
 
     Box(
         modifier =
@@ -368,29 +370,12 @@ private fun SyllableWord(
             }
     ) {
         // Ghost text for layout consistency
-        Text(
-            text = word.text,
-            style =
-                remember(maxWordWeight, maxWordWidth, textPrefs, expressiveSyllables) {
-                    textStyle.copy(
-                        fontFamily =
-                            if (expressiveSyllables) {
-                                flexFontEmphasis(
-                                    fontWeight = maxWordWeight,
-                                    fontWidth = maxWordWidth,
-                                )
-                            } else {
-                                fontFamily
-                            }
-                    )
-                },
-            modifier = Modifier.alpha(0f),
-        )
+        Text(text = word.text, style = textStyle2, modifier = Modifier.alpha(0f))
 
         // Undertext + Glow
         Text(
             text = word.text,
-            style = textStyle,
+            style = animatedTextStyle,
             color = textColor.copy(alpha = underTextAlpha),
             modifier =
                 Modifier.matchParentSize()
@@ -400,7 +385,7 @@ private fun SyllableWord(
         // Main Highlight Layer with Mask
         Text(
             text = word.text,
-            style = textStyle,
+            style = animatedTextStyle,
             color = textColor,
             modifier =
                 Modifier.matchParentSize()
@@ -536,7 +521,7 @@ fun SyllableSyncedLyricsPreview() {
                             ttmlLyrics = ttmlLyrics,
                         )
                 ),
-            expressiveSyllables = false,
+            expressiveSyllables = true,
             playingSong = PlayingSong(title = "Preview Song", artist = "Rush"),
         )
 

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/SyllableSyncedLyrics.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/SyllableSyncedLyrics.kt
@@ -332,7 +332,7 @@ private fun SyllableWord(
             textAlign = textPrefs.lyricsAlignment.toTextAlignment(),
         )
     val textStyle1 =
-        remember(maxWordWeight, maxWordWidth, textPrefs, expressiveSyllables) {
+        remember(baseTextStyle, expressiveSyllables) {
             if (expressiveSyllables) {
                 baseTextStyle.copy(
                     fontFamily = flexFontEmphasis(fontWeight = 300, fontWidth = 100f)
@@ -340,7 +340,7 @@ private fun SyllableWord(
             } else baseTextStyle
         }
     val textStyle2 =
-        remember(maxWordWeight, maxWordWidth, textPrefs, expressiveSyllables) {
+        remember(textStyle1, maxWordWidth, maxWordWeight, expressiveSyllables) {
             if (expressiveSyllables) {
                 textStyle1.copy(
                     fontFamily =

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/customisation/LyricsCustomisationPreview.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/customisation/LyricsCustomisationPreview.kt
@@ -92,7 +92,8 @@ fun LyricsCustomisationPreview(
                     ParsedWord("an", 3.6, 3.8),
                     ParsedWord("example", 3.8, 4.5),
                     ParsedWord("of", 4.5, 4.7),
-                    ParsedWord("Syllable-Synced", 4.7, 6.0),
+                    ParsedWord("Syllable", 4.7, 5.2),
+                    ParsedWord("Synced", 5.2, 6.0),
                     ParsedWord("Lyrics", 6.0, 6.5),
                 ),
         )

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/customisation/LyricsCustomisationSettings.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/customisation/LyricsCustomisationSettings.kt
@@ -99,7 +99,9 @@ fun LazyListScope.lyricsCustomisationSettings(
                 ListItem(
                     colors = listItemColors(),
                     modifier = Modifier.clip(middleItemShape()),
-                    headlineContent = { Text(text = stringResource(R.string.expressive_syllables)) },
+                    headlineContent = {
+                        Text(text = stringResource(R.string.expressive_syllables))
+                    },
                     supportingContent = {
                         Text(
                             text = stringResource(R.string.expressive_syllables_desc),

--- a/app/src/main/java/com/shub39/rush/presentation/lyrics/component/customisation/LyricsCustomisationSettings.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/lyrics/component/customisation/LyricsCustomisationSettings.kt
@@ -99,12 +99,10 @@ fun LazyListScope.lyricsCustomisationSettings(
                 ListItem(
                     colors = listItemColors(),
                     modifier = Modifier.clip(middleItemShape()),
-                    headlineContent = { Text(text = "Enable Expressive Syllables") },
+                    headlineContent = { Text(text = stringResource(R.string.expressive_syllables)) },
                     supportingContent = {
                         Text(
-                            text =
-                                "[Experimental] Font weight and Font Width are animated based" +
-                                    " on duration of the word. Might cause stutters and glitches",
+                            text = stringResource(R.string.expressive_syllables_desc),
                             modifier = Modifier.basicMarquee(),
                         )
                     },

--- a/app/src/main/java/com/shub39/rush/presentation/setting/section/SettingRootPage.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/setting/section/SettingRootPage.kt
@@ -281,7 +281,7 @@ fun SettingRootPage(
                             )
                         },
                         supportingContent = {
-                            Text(text = "Grit ${state.changelog.firstOrNull()?.version ?: "x.x.x"}")
+                            Text(text = "Rush ${state.changelog.firstOrNull()?.version ?: "x.x.x"}")
                         },
                         trailingContent = {
                             Icon(

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -156,4 +156,8 @@
     <string name="romanization">Transkrypcja</string>
     <string name="romanization_desc">Pokazuj transkrypcję tekstów piosenek dla Japońskiego, Koreańskiego, Chińskiego, Hindi, Punjabi i Cyrylicy</string>
     <string name="open_search">Otwórz wyszukiwanie</string>
+    <string name="bmc_desc">Wspomórz mnie robiąc małą wpłatę</string>
+    <string name="translate_desc">Przetłumacz Rush na twój język</string>
+    <string name="system_default">Domyślny Systemowy</string>
+    <string name="language">Język</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,4 +159,6 @@
     <string name="open_search">Open Search</string>
     <string name="system_default">System Default</string>
     <string name="language">Language</string>
+    <string name="expressive_syllables">Expressive Syllables</string>
+    <string name="expressive_syllables_desc">Font style changes based on word duration</string>
 </resources>


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * App updated to version 6.2.0; changelog entry added.

* **Bug Fixes**
  * Fixed crashes related to Expressive Syllables.
  * Resolved UI inconsistencies affecting synced lyrics display.

* **New Features**
  * Improved expressive syllables styling and animated highlight behavior for synced lyrics.
  * Added user-facing strings for Expressive Syllables and new Polish translations.

* **Updates**
  * Refined syllable timing in previews and About screen version display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shub39/Rush/pull/264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bumps the app to version 6.2.0 and reworks the expressive-syllables animation in `SyllableSyncedLyrics`: font weight/width are no longer lerped per-frame. Instead, two static `TextStyle` objects (light start state and heavy end state) are rendered in stacked `Box` layers and a horizontal gradient wipe driven by `animatedProgress` reveals the heavier style.

- **Rendering overhaul:** the word highlight now uses a `DstIn`-masked `Brush.horizontalGradient` sweep rather than a continuously re-computed variable-font axis value, eliminating per-tick layout pressure.
- **String externalization:** the Expressive Syllables toggle label/description are moved from hardcoded strings to `R.string` resources; Polish translations for four previously missing strings are added (though `expressive_syllables` and `expressive_syllables_desc` remain absent from `values-pl`).
- **Misc fixes:** the About screen \"Grit\" typo is corrected to \"Rush\", preview syllable timing is split into two words for better preview accuracy, and `expressiveSyllables = true` is now used in the preview.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; the animation rework is self-contained and the previous issues flagged in review are all addressed.

The changes replace a per-frame variable-font interpolation with two static TextStyle objects and a gradient wipe. All four concerns raised in the previous review round — stale closure on baseTextStyle, object allocation per recomposition, missing animationSpec on textStyleAnim, and dead commented-out code — are resolved in this revision. The remaining gap (missing expressive_syllables Polish strings) was already noted in a prior thread and causes only an English fallback, not a crash or data loss.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/src/main/java/com/shub39/rush/presentation/lyrics/component/SyllableSyncedLyrics.kt | Core animation rework: replaces per-frame lerped font weight/width with two static TextStyle objects and a DstIn gradient wipe; previous issues (stale closure, object allocation, dead code, missing animationSpec) all addressed. |
| app/src/main/java/com/shub39/rush/presentation/lyrics/component/customisation/LyricsCustomisationSettings.kt | Hardcoded English strings replaced with R.string references for expressive syllables toggle. |
| app/src/main/res/values-pl/strings.xml | Four previously missing Polish strings added; expressive_syllables and expressive_syllables_desc still absent, Polish users will see English fallback for those two strings. |
| app/src/main/java/com/shub39/rush/presentation/setting/section/SettingRootPage.kt | One-line typo fix: 'Grit' corrected to 'Rush' in the About screen version display. |
| app/build.gradle.kts | Version bumped from 6.1.15 / 6115 to 6.2.0 / 6200. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    SW["SyllableWord()"]
    BS["baseTextStyle\n(bodyLarge + textPrefs)"]
    TS1["textStyle1\nremember(baseTextStyle, expressiveSyllables)\n→ light font weight=300, width=100f"]
    TS2["textStyle2\nremember(textStyle1, maxWordWeight, maxWordWidth, expressiveSyllables)\n→ heavy font weight=maxWordWeight, width=maxWordWidth"]

    SW --> BS --> TS1 --> TS2

    TS2 -->|"alpha(0f)"| SKEL["Skeleton Text\n(holds layout at max-weight size)"]

    TS1 -->|"underTextAlpha"| GLOW["Glow Box\n.blur(glowAlpha.dp)\n.graphicsLayer(Offscreen)\n.drawWithContent DstIn\nkeep RIGHT side (not yet highlighted)"]

    TS2 --> MAIN["Highlight Box\n.graphicsLayer(Offscreen)\n.drawWithContent DstIn\nkeep LEFT side (already highlighted)"]

    AP["animatedProgress\n(fastSpatialSpec)"] -->|"drives wipe position"| GLOW
    AP -->|"drives wipe position"| MAIN
```
</details>

<sub>Reviews (4): Last reviewed commit: [":wrench: chore: fixed nitpicks"](https://github.com/shub39/rush/commit/a037b3caa743ca5cf731a448848b6e5910dbf11c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32546305)</sub>

<!-- /greptile_comment -->