### PR TITLE
:wrench: fix: search sheet overlapped by keyboard

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
         <activity
             android:name=".app.MainActivity"
             android:exported="true"
+            android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.Rush.Splash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/shub39/rush/app/App.kt
+++ b/app/src/main/java/com/shub39/rush/app/App.kt
@@ -19,7 +19,6 @@ package com.shub39.rush.app
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -186,7 +185,6 @@ fun App() {
                 state = searchState,
                 onAction = searchSheetVM::onAction,
                 onNavigateToLyrics = { backStack.add(LyricsGraph) },
-                sheetState = rememberModalBottomSheetState(),
             )
         }
     }

--- a/app/src/main/java/com/shub39/rush/presentation/searchsheet/SearchSheet.kt
+++ b/app/src/main/java/com/shub39/rush/presentation/searchsheet/SearchSheet.kt
@@ -21,8 +21,13 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
@@ -32,9 +37,12 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -45,11 +53,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.SheetState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -62,6 +68,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
@@ -89,7 +96,6 @@ fun SearchSheet(
     state: SearchSheetState,
     onAction: (SearchSheetAction) -> Unit,
     onNavigateToLyrics: () -> Unit,
-    sheetState: SheetState,
     modifier: Modifier = Modifier,
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -97,142 +103,142 @@ fun SearchSheet(
     val focusManager = LocalFocusManager.current
     val focusRequester = remember { FocusRequester() }
 
-    if (state.visible) {
-        ModalBottomSheet(
-            sheetState = sheetState,
-            modifier = modifier.widthIn(max = 800.dp),
-            onDismissRequest = { onAction(SearchSheetAction.OnToggleSearchSheet) },
-        ) {
-            val isImeVisible = WindowInsets.isImeVisible
+    AnimatedVisibility(
+        visible = state.visible,
+        enter =
+            fadeIn(animationSpec = tween(300)) +
+                slideInVertically(animationSpec = tween(300), initialOffsetY = { it }),
+        exit =
+            fadeOut(animationSpec = tween(300)) +
+                slideOutVertically(animationSpec = tween(300), targetOffsetY = { it }),
+    ) {
+        Box(modifier = Modifier.fillMaxSize()) {
+            // Scrim
+            Box(
+                modifier =
+                    Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.32f)).clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                    ) {
+                        onAction(SearchSheetAction.OnToggleSearchSheet)
+                    }
+            )
 
-            BackHandler(enabled = isImeVisible) {
-                focusManager.clearFocus()
-                keyboardController?.hide()
-            }
-
-            LaunchedEffect(Unit) {
-                delay(400)
-                focusRequester.requestFocus()
-                keyboardController?.show()
-            }
-
-            Column(
-                modifier = Modifier.fillMaxSize(),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Top,
+            // Sheet content
+            Surface(
+                modifier =
+                    Modifier.align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                        .widthIn(max = 800.dp)
+                        .clip(RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp))
+                        .imePadding(),
+                color = MaterialTheme.colorScheme.surface,
+                tonalElevation = 3.dp,
+                shadowElevation = 8.dp,
             ) {
-                OutlinedTextField(
-                    value = state.searchQuery,
-                    singleLine = true,
-                    leadingIcon = {
-                        Icon(
-                            painter = painterResource(R.drawable.search),
-                            contentDescription = "Search",
-                            modifier = Modifier.padding(2.dp),
-                        )
-                    },
-                    trailingIcon = {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.padding(2.dp),
-                        ) {
-                            AnimatedVisibility(
-                                visible = state.searchQuery.isNotBlank(),
-                                enter = fadeIn(animationSpec = tween(200)),
-                                exit = fadeOut(animationSpec = tween(200)),
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Box(
+                        modifier =
+                            Modifier.padding(top = 12.dp)
+                                .width(40.dp)
+                                .height(4.dp)
+                                .clip(RoundedCornerShape(2.dp))
+                                .background(
+                                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+                                )
+                    )
+
+                    OutlinedTextField(
+                        value = state.searchQuery,
+                        singleLine = true,
+                        leadingIcon = {
+                            Icon(
+                                painter = painterResource(R.drawable.search),
+                                contentDescription = "Search",
+                                modifier = Modifier.padding(2.dp),
+                            )
+                        },
+                        trailingIcon = {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier.padding(2.dp),
                             ) {
-                                IconButton(
-                                    onClick = {
-                                        onAction(SearchSheetAction.OnQueryChange(""))
-                                        coroutineScope.launch {
-                                            focusRequester.requestFocus()
-                                            keyboardController?.show()
-                                        }
-                                    }
+                                AnimatedVisibility(
+                                    visible = state.searchQuery.isNotBlank(),
+                                    enter = fadeIn(animationSpec = tween(200)),
+                                    exit = fadeOut(animationSpec = tween(200)),
                                 ) {
-                                    Icon(
-                                        painter = painterResource(R.drawable.delete),
-                                        contentDescription = "Delete",
-                                    )
+                                    IconButton(
+                                        onClick = {
+                                            onAction(SearchSheetAction.OnQueryChange(""))
+                                            coroutineScope.launch {
+                                                focusRequester.requestFocus()
+                                                keyboardController?.show()
+                                            }
+                                        }
+                                    ) {
+                                        Icon(
+                                            painter = painterResource(R.drawable.delete),
+                                            contentDescription = "Delete",
+                                        )
+                                    }
                                 }
                             }
-                        }
-                    },
-                    onValueChange = { onAction(SearchSheetAction.OnQueryChange(it)) },
-                    shape = MaterialTheme.shapes.extraLarge,
-                    placeholder = { Text(stringResource(R.string.search)) },
-                    modifier =
-                        Modifier.fillMaxWidth()
-                            .padding(start = 16.dp, end = 16.dp, bottom = 16.dp)
-                            .focusRequester(focusRequester),
-                    keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Search),
-                    keyboardActions = KeyboardActions(onSearch = { keyboardController?.hide() }),
-                )
+                        },
+                        onValueChange = { onAction(SearchSheetAction.OnQueryChange(it)) },
+                        shape = MaterialTheme.shapes.extraLarge,
+                        placeholder = { Text(stringResource(R.string.search)) },
+                        modifier =
+                            Modifier.fillMaxWidth()
+                                .padding(start = 16.dp, end = 16.dp, bottom = 8.dp, top = 8.dp)
+                                .focusRequester(focusRequester),
+                        keyboardOptions =
+                            KeyboardOptions.Default.copy(imeAction = ImeAction.Search),
+                        keyboardActions = KeyboardActions(onSearch = { keyboardController?.hide() }),
+                    )
 
-                LazyColumn(
-                    modifier =
-                        Modifier.padding(horizontal = 16.dp)
-                            .clip(RoundedCornerShape(16.dp))
-                            .fillMaxSize(),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(2.dp),
-                    contentPadding = PaddingValues(top = 16.dp, bottom = 60.dp),
-                ) {
-                    state.error?.let { error ->
-                        item {
-                            ErrorCard(
-                                error = error,
-                                debugMessage = null,
-                                colors =
-                                    Pair(
-                                        MaterialTheme.colorScheme.onSurface,
-                                        MaterialTheme.colorScheme.background,
-                                    ),
-                            )
-                        }
-                    }
-
-                    itemsIndexed(
-                        items = state.localSearchResults,
-                        key = { _, it -> "Saved_${it.id}" },
-                    ) { index, it ->
-                        val shape =
-                            when {
-                                state.localSearchResults.size == 1 -> detachedItemShape()
-                                index == 0 -> leadingItemShape()
-                                index == state.localSearchResults.lastIndex -> endItemShape()
-                                else -> middleItemShape()
+                    LazyColumn(
+                        modifier =
+                            Modifier.padding(horizontal = 16.dp)
+                                .clip(RoundedCornerShape(16.dp))
+                                .heightIn(max = 480.dp)
+                                .fillMaxWidth(),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(2.dp),
+                        contentPadding = PaddingValues(top = 8.dp, bottom = 60.dp),
+                    ) {
+                        state.error?.let { error ->
+                            item {
+                                ErrorCard(
+                                    error = error,
+                                    debugMessage = null,
+                                    colors =
+                                        Pair(
+                                            MaterialTheme.colorScheme.onSurface,
+                                            MaterialTheme.colorScheme.background,
+                                        ),
+                                )
                             }
+                        }
 
-                        SearchResultCard(
-                            result = it,
-                            downloaded = true,
-                            modifier =
-                                Modifier.clip(shape).clickable {
-                                    onAction(SearchSheetAction.OnCardClicked(it.id))
-                                    onNavigateToLyrics()
-                                },
-                        )
-                    }
-
-                    if (state.localSearchResults.isNotEmpty()) {
-                        item { Spacer(modifier = Modifier.height(16.dp)) }
-                    }
-
-                    if (!state.isSearching) {
-                        itemsIndexed(items = state.searchResults, key = { _, it -> it.id }) {
-                            index,
-                            it ->
+                        itemsIndexed(
+                            items = state.localSearchResults,
+                            key = { _, it -> "Saved_${it.id}" },
+                        ) { index, it ->
                             val shape =
                                 when {
-                                    state.searchResults.size == 1 -> detachedItemShape()
+                                    state.localSearchResults.size == 1 -> detachedItemShape()
                                     index == 0 -> leadingItemShape()
-                                    index == state.searchResults.lastIndex -> endItemShape()
+                                    index == state.localSearchResults.lastIndex -> endItemShape()
                                     else -> middleItemShape()
                                 }
 
                             SearchResultCard(
                                 result = it,
+                                downloaded = true,
                                 modifier =
                                     Modifier.clip(shape).clickable {
                                         onAction(SearchSheetAction.OnCardClicked(it.id))
@@ -240,10 +246,55 @@ fun SearchSheet(
                                     },
                             )
                         }
-                    } else {
-                        item { LoadingIndicator(modifier = Modifier.size(60.dp)) }
+
+                        if (state.localSearchResults.isNotEmpty()) {
+                            item { Spacer(modifier = Modifier.height(16.dp)) }
+                        }
+
+                        if (!state.isSearching) {
+                            itemsIndexed(items = state.searchResults, key = { _, it -> it.id }) {
+                                index,
+                                it ->
+                                val shape =
+                                    when {
+                                        state.searchResults.size == 1 -> detachedItemShape()
+                                        index == 0 -> leadingItemShape()
+                                        index == state.searchResults.lastIndex -> endItemShape()
+                                        else -> middleItemShape()
+                                    }
+
+                                SearchResultCard(
+                                    result = it,
+                                    modifier =
+                                        Modifier.clip(shape).clickable {
+                                            onAction(SearchSheetAction.OnCardClicked(it.id))
+                                            onNavigateToLyrics()
+                                        },
+                                )
+                            }
+                        } else {
+                            item { LoadingIndicator(modifier = Modifier.size(60.dp)) }
+                        }
                     }
                 }
+            }
+
+            // Handle back: hide keyboard if visible, otherwise dismiss search
+            val isImeVisible = WindowInsets.isImeVisible
+            BackHandler(enabled = true) {
+                if (isImeVisible) {
+                    focusManager.clearFocus()
+                    keyboardController?.hide()
+                } else {
+                    onAction(SearchSheetAction.OnToggleSearchSheet)
+                }
+            }
+
+            // Auto-focus and show keyboard when sheet opens
+            LaunchedEffect(Unit) {
+                delay(400)
+                focusRequester.requestFocus()
+                keyboardController?.show()
             }
         }
     }
@@ -259,10 +310,5 @@ private fun Preview() {
         )
     }
 
-    SearchSheet(
-        state = state,
-        onAction = {},
-        onNavigateToLyrics = {},
-        sheetState = rememberStandardBottomSheetState(),
-    )
+    SearchSheet(state = state, onAction = {}, onNavigateToLyrics = {})
 }


### PR DESCRIPTION
ModalBottomSheet renders in a Popup window which doesn't receive IME insets, so imePadding() was always 0 inside it. Replaced with custom inline bottom sheet rendered in the activity layout so IME insets work properly. Also fixed back press to dismiss sheet when keyboard hidden.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard interaction and visibility handling in the search interface
  * Enhanced keyboard dismissal behavior when navigating the search sheet

* **UI/UX Improvements**
  * Refined search sheet animation and overlay styling for a smoother user experience

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shub39/Rush/pull/266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->