### PR TITLE
build: add desktopOnly flag to isolate desktop compilation

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,10 +41,13 @@ dependencyResolutionManagement {
     }
 }
 
+val desktopOnly = providers.gradleProperty("desktopOnly").orNull?.toBoolean() ?: false
+
 include(":shared:core", ":shared:ui", ":shared:logic")
 
-include(":androidLibs:romanization", ":androidLibs:visualizer-helper")
-
-include(":androidApp")
+if (!desktopOnly) {
+    include(":androidLibs:romanization", ":androidLibs:visualizer-helper")
+    include(":androidApp")
+}
 
 include(":desktopApp")

--- a/shared/core/build.gradle.kts
+++ b/shared/core/build.gradle.kts
@@ -14,10 +14,18 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+import org.gradle.api.plugins.ExtensionAware
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.android.kotlin.multiplatform.library)
+    alias(libs.plugins.android.kotlin.multiplatform.library) apply false
+}
+
+val desktopOnly = providers.gradleProperty("desktopOnly").orNull?.toBoolean() ?: false
+
+if (!desktopOnly) {
+    apply(plugin = rootProject.libs.plugins.android.kotlin.multiplatform.library.get().pluginId)
 }
 
 kotlin {
@@ -26,11 +34,21 @@ kotlin {
         freeCompilerArgs.add("-Xexpect-actual-classes")
     }
 
-    android {
-        namespace = "com.shub39.rush.shared.core"
-        compileSdk { version = release(libs.versions.compileSdk.get().toInt()) }
-        minSdk { version = release(libs.versions.minSdk.get().toInt()) }
-        withHostTest {}
+    if (!desktopOnly) {
+        val androidExt = (this as ExtensionAware).extensions.getByName("android")
+        androidExt.javaClass
+            .getMethod("setNamespace", String::class.java)
+            .invoke(androidExt, "com.shub39.rush.shared.core")
+        androidExt.javaClass
+            .getMethod("setCompileSdk", Int::class.javaObjectType)
+            .invoke(androidExt, libs.versions.compileSdk.get().toInt())
+        androidExt.javaClass
+            .getMethod("setMinSdk", Int::class.javaObjectType)
+            .invoke(androidExt, libs.versions.minSdk.get().toInt())
+
+        val withHostTest =
+            androidExt.javaClass.getMethod("withHostTest", org.gradle.api.Action::class.java)
+        withHostTest.invoke(androidExt, org.gradle.api.Action<Any> {})
     }
 
     jvm()

--- a/shared/logic/build.gradle.kts
+++ b/shared/logic/build.gradle.kts
@@ -15,11 +15,12 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import java.util.Properties
+import org.gradle.api.plugins.ExtensionAware
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.android.kotlin.multiplatform.library)
+    alias(libs.plugins.android.kotlin.multiplatform.library) apply false
     alias(libs.plugins.compose.multiplatform)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.build.config)
@@ -28,19 +29,45 @@ plugins {
     alias(libs.plugins.koin.compiler)
 }
 
+val desktopOnly = providers.gradleProperty("desktopOnly").orNull?.toBoolean() ?: false
+
+if (!desktopOnly) {
+    apply(plugin = rootProject.libs.plugins.android.kotlin.multiplatform.library.get().pluginId)
+}
+
 kotlin {
     compilerOptions {
         freeCompilerArgs.add("-Xcontext-sensitive-resolution")
         freeCompilerArgs.add("-Xexpect-actual-classes")
     }
 
-    android {
-        namespace = "com.shub39.rush.shared.logic"
-        compileSdk { version = release(libs.versions.compileSdk.get().toInt()) }
-        minSdk { version = release(libs.versions.minSdk.get().toInt()) }
-        withHostTest {}
+    if (!desktopOnly) {
+        val androidExt = (this as ExtensionAware).extensions.getByName("android")
+        androidExt.javaClass
+            .getMethod("setNamespace", String::class.java)
+            .invoke(androidExt, "com.shub39.rush.shared.logic")
+        androidExt.javaClass
+            .getMethod("setCompileSdk", Int::class.javaObjectType)
+            .invoke(androidExt, libs.versions.compileSdk.get().toInt())
+        androidExt.javaClass
+            .getMethod("setMinSdk", Int::class.javaObjectType)
+            .invoke(androidExt, libs.versions.minSdk.get().toInt())
 
-        androidResources { enable = true }
+        val withHostTest =
+            androidExt.javaClass.getMethod("withHostTest", org.gradle.api.Action::class.java)
+        withHostTest.invoke(androidExt, org.gradle.api.Action<Any> {})
+
+        val androidResources =
+            androidExt.javaClass.getMethod("androidResources", org.gradle.api.Action::class.java)
+        androidResources.invoke(
+            androidExt,
+            org.gradle.api.Action<Any> {
+                val rc: Any = this
+                rc.javaClass
+                    .getMethod("setEnable", Boolean::class.javaPrimitiveType)
+                    .invoke(rc, true)
+            },
+        )
     }
 
     jvm()
@@ -68,7 +95,11 @@ kotlin {
             implementation(libs.bundles.ktor)
             implementation(libs.ksoup)
         }
-        androidMain.dependencies { implementation(projects.androidLibs.romanization) }
+        if (!desktopOnly) {
+            findByName("androidMain")?.dependencies {
+                implementation(project(":androidLibs:romanization"))
+            }
+        }
         jvmMain.dependencies { implementation(libs.androidx.sqlite.bundled) }
     }
 }
@@ -98,7 +129,9 @@ room3 { schemaDirectory("$projectDir/schemas") }
 
 dependencies {
     add("kspJvm", libs.androidx.room.compiler)
-    add("kspAndroid", libs.androidx.room.compiler)
+    if (!desktopOnly) {
+        add("kspAndroid", libs.androidx.room.compiler)
+    }
 }
 
 val generateChangelogJson by

--- a/shared/ui/build.gradle.kts
+++ b/shared/ui/build.gradle.kts
@@ -15,13 +15,21 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import org.gradle.api.plugins.ExtensionAware
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.android.kotlin.multiplatform.library)
+    alias(libs.plugins.android.kotlin.multiplatform.library) apply false
     alias(libs.plugins.compose.multiplatform)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.koin.compiler)
+}
+
+val desktopOnly = providers.gradleProperty("desktopOnly").orNull?.toBoolean() ?: false
+
+if (!desktopOnly) {
+    apply(plugin = rootProject.libs.plugins.android.kotlin.multiplatform.library.get().pluginId)
 }
 
 kotlin {
@@ -42,11 +50,29 @@ kotlin {
         )
     }
 
-    android {
-        namespace = "com.shub39.rush.shared.ui"
-        compileSdk { version = release(libs.versions.compileSdk.get().toInt()) }
-        minSdk { version = release(libs.versions.minSdk.get().toInt()) }
-        androidResources { enable = true }
+    if (!desktopOnly) {
+        val androidExt = (this as ExtensionAware).extensions.getByName("android")
+        androidExt.javaClass
+            .getMethod("setNamespace", String::class.java)
+            .invoke(androidExt, "com.shub39.rush.shared.ui")
+        androidExt.javaClass
+            .getMethod("setCompileSdk", Int::class.javaObjectType)
+            .invoke(androidExt, libs.versions.compileSdk.get().toInt())
+        androidExt.javaClass
+            .getMethod("setMinSdk", Int::class.javaObjectType)
+            .invoke(androidExt, libs.versions.minSdk.get().toInt())
+
+        val androidResources =
+            androidExt.javaClass.getMethod("androidResources", org.gradle.api.Action::class.java)
+        androidResources.invoke(
+            androidExt,
+            org.gradle.api.Action<Any> {
+                val rc: Any = this
+                rc.javaClass
+                    .getMethod("setEnable", Boolean::class.javaPrimitiveType)
+                    .invoke(rc, true)
+            },
+        )
     }
 
     jvm()
@@ -79,20 +105,44 @@ kotlin {
             implementation(libs.koin.compose.viewmodel.navigation)
             implementation(libs.koin.annotations)
         }
-        androidMain.dependencies {
-            implementation(projects.androidLibs.visualizerHelper)
-            implementation(libs.accompanist.permissions)
+        if (!desktopOnly) {
+            findByName("androidMain")?.dependencies {
+                implementation(project(":androidLibs:visualizer-helper"))
+                implementation(libs.accompanist.permissions)
+            }
         }
     }
 }
 
 dependencies {
-    androidRuntimeClasspath(libs.compose.ui.tooling)
-    androidRuntimeClasspath(libs.compose.ui.tooling.preview)
+    if (!desktopOnly) {
+        add("androidRuntimeClasspath", libs.compose.ui.tooling)
+        add("androidRuntimeClasspath", libs.compose.ui.tooling.preview)
+    }
 }
 
-androidComponents {
-    onVariants { variant ->
-        variant.sources.res?.addStaticSourceDirectory("src/commonMain/composeResources")
-    }
+plugins.withId("com.android.kotlin.multiplatform.library") {
+    val componentsExt = extensions.getByName("androidComponents")
+    val selector = componentsExt.javaClass.getMethod("selector").invoke(componentsExt)
+    val allSelector = selector.javaClass.getMethod("all").invoke(selector)
+
+    val onVariantsMethod =
+        componentsExt.javaClass.methods.first {
+            it.name == "onVariants" &&
+                it.parameterCount == 2 &&
+                it.parameterTypes[1] == org.gradle.api.Action::class.java
+        }
+
+    onVariantsMethod.invoke(
+        componentsExt,
+        allSelector,
+        org.gradle.api.Action<Any> {
+            val variant = this
+            val sources = variant.javaClass.getMethod("getSources").invoke(variant)
+            val res = sources.javaClass.getMethod("getRes").invoke(sources)
+            res?.javaClass
+                ?.getMethod("addStaticSourceDirectory", String::class.java)
+                ?.invoke(res, "src/commonMain/composeResources")
+        },
+    )
 }


### PR DESCRIPTION
Hi! I slopinated this PR using a LLM to make packaging Rush for package managers (like Nix) easier. 

Right now, compiling the desktop app in offline or sandboxed build environments fails because Gradle requires the Android SDK and Git metadata to configure the build graph.

To solve this, we introduced a `-PdesktopOnly=true` Gradle property:
* **Settings**: It conditionally excludes the `:androidApp` and `:androidLibs` modules from the build tree when the flag is enabled.
* **Build Scripts**: It applies the Android library plugins and target configuration blocks dynamically using reflection, avoiding compile-time dependency issues when compiling without the Android SDK.
* **Dependencies**: Changed type-safe project accessors to string project lookups to keep Gradle happy when modules are excluded.

Standard builds (default behavior without the flag) are completely unaffected. We verified both standard and sandboxed builds locally, and spotless formatting checks passed.
