### PR TITLE
:wrench: fix: preserve millisecond precision in playerctl position and seek

### DIFF
--- a/shared/core/src/jvmMain/kotlin/com/shub39/rush/shared/core/listener/MediaListener.jvm.kt
+++ b/shared/core/src/jvmMain/kotlin/com/shub39/rush/shared/core/listener/MediaListener.jvm.kt
@@ -60,7 +60,7 @@ actual object MediaListener {
     actual fun seek(timeStamp: Long) {
         coroutineScope.launch {
             try {
-                executeCommand("playerctl position ${(timeStamp/1000).toInt()}")
+                executeCommand("playerctl position ${timeStamp / 1000.0}")
                 songPositionFlow.emit(timeStamp)
             } catch (e: Exception) {
                 e.printStackTrace()
@@ -122,8 +122,8 @@ actual object MediaListener {
             val artist = cleanOutput(metadataArtist)?.substringAfter("xesam:artist ")?.trim() ?: ""
             songInfoFlow.emit(SongMeta(title = getMainTitle(title), artist = getMainArtist(artist)))
 
-            val positionLong = position?.trim()?.toFloatOrNull()?.toLong() ?: 0L
-            songPositionFlow.emit(positionLong * 1000)
+            val positionMs = position?.trim()?.toDoubleOrNull()?.let { (it * 1000).toLong() } ?: 0L
+            songPositionFlow.emit(positionMs)
         } catch (e: Exception) {
             RushLogger.e("MediaListener", "Error updating Media Info", e)
         }


### PR DESCRIPTION
The `.toLong()` in `MediaListener.jvm.kt` drops the decimal places before multiplying by 1000:

```kotlin
val positionLong = position?.trim()?.toFloatOrNull()?.toLong() ?: 0L
songPositionFlow.emit(positionLong * 1000)
```

For example:
`playerctl position` → `241.904000`
Gets converted to `241L` → `241000ms` (losing 904ms).

This caused an average lag of 500ms behind the audio during synced playback on Linux.

### Changes
- Multiplied by 1000 before converting to `Long` to keep millisecond precision.
- Changed `seek()` to pass decimal seconds (`timeStamp / 1000.0`) to `playerctl position` instead of whole seconds.